### PR TITLE
using voila specific kernel manager

### DIFF
--- a/share/jupyter/voila/templates/classic/index.html.j2
+++ b/share/jupyter/voila/templates/classic/index.html.j2
@@ -22,7 +22,7 @@
     {%- set kernel_id = kernel_start() -%}
     <script id="jupyter-config-data" type="application/json">
     {
-        "baseUrl": "{{resources.base_url}}",
+        "baseUrl": "{{resources.base_url}}voila/",
         "kernelId": "{{kernel_id}}"
     }
     </script>

--- a/share/jupyter/voila/templates/lab/index.html.j2
+++ b/share/jupyter/voila/templates/lab/index.html.j2
@@ -35,7 +35,7 @@ var voila_process = function(cell_index, cell_count) {
   {%- with kernel_id = kernel_start() -%}
     <script id="jupyter-config-data" type="application/json">
     {
-        "baseUrl": "{{resources.base_url}}",
+        "baseUrl": "{{resources.base_url}}voila/",
         "kernelId": "{{kernel_id}}"
     }
     </script>

--- a/tests/app/execute_test.py
+++ b/tests/app/execute_test.py
@@ -28,7 +28,7 @@ async def test_no_execute_allowed(voila_app, app, http_server_client, base_url, 
     kernel_id = groups[0]
     print(kernel_id, base_url)
     session_id = '445edd75-c6f5-45d2-8b58-5fe8f84a7123'
-    url = f'ws://localhost:{http_server_port[1]}{base_url}api/kernels/{kernel_id}/channels?session_id={session_id}'
+    url = f'ws://localhost:{http_server_port[1]}{base_url}voila/api/kernels/{kernel_id}/channels?session_id={session_id}'
     conn = await tornado.websocket.websocket_connect(url)
 
     msg = {

--- a/tests/server/kernel_manager_test.py
+++ b/tests/server/kernel_manager_test.py
@@ -1,0 +1,13 @@
+import json
+
+
+async def test_api_kernels_endpoint(http_server_client, print_notebook_url):
+    # start a voila kernel
+    await http_server_client.fetch(print_notebook_url)
+
+    response = await http_server_client.fetch("/voila/api/kernels")
+    assert response.code == 200
+
+    kernels = json.loads(response.body)
+    assert len(kernels) == 1
+    assert "id" in kernels[0]

--- a/voila/app.py
+++ b/voila/app.py
@@ -40,7 +40,7 @@ from traitlets.config.loader import Config
 from traitlets import Unicode, Integer, Bool, Dict, List, default
 
 from jupyter_server.services.kernels.kernelmanager import AsyncMappingKernelManager
-from jupyter_server.services.kernels.handlers import KernelHandler, ZMQChannelsHandler
+from jupyter_server.services.kernels.handlers import MainKernelHandler, KernelHandler, ZMQChannelsHandler
 from jupyter_server.services.contents.largefilemanager import LargeFileManager
 from jupyter_server.base.handlers import FileFindHandler, path_regex
 from jupyter_server.config_manager import recursive_update
@@ -70,6 +70,12 @@ _kernel_id_regex = r"(?P<kernel_id>\w+-\w+-\w+-\w+-\w+)"
 
 def _(x):
     return x
+
+
+class VoilaMainKernelHandler(MainKernelHandler):
+    @property
+    def kernel_manager(self):
+        return self.settings['voila_kernel_manager']
 
 
 class VoilaKernelHandler(KernelHandler):
@@ -589,6 +595,7 @@ class Voila(Application):
 main = Voila.launch_instance
 
 base_handlers = [
+    (r'/voila/api/kernels', VoilaMainKernelHandler),
     (r'/voila/api/kernels/%s' % _kernel_id_regex, VoilaKernelHandler),
     (r'/voila/api/kernels/%s/channels' % _kernel_id_regex, VoilaZMQChannelsHandler),
 ]

--- a/voila/app.py
+++ b/voila/app.py
@@ -400,6 +400,7 @@ class Voila(Application):
                 'comm_msg',
                 'comm_info_request',
                 'kernel_info_request',
+                'custom_message',
                 'shutdown_request'
             ]
         )

--- a/voila/app.py
+++ b/voila/app.py
@@ -71,6 +71,7 @@ _kernel_id_regex = r"(?P<kernel_id>\w+-\w+-\w+-\w+-\w+)"
 def _(x):
     return x
 
+
 class VoilaKernelHandler(KernelHandler):
     @property
     def kernel_manager(self):

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -32,6 +32,10 @@ class VoilaHandler(JupyterHandler):
         # we want to avoid starting multiple kernels due to template mistakes
         self.kernel_started = False
 
+    @property
+    def kernel_manager(self):
+        return self.settings['voila_kernel_manager']
+
     @tornado.web.authenticated
     async def get(self, path=None):
         # if the handler got a notebook_path argument, always serve that

--- a/voila/server_extension.py
+++ b/voila/server_extension.py
@@ -75,7 +75,7 @@ def _load_jupyter_server_extension(server_app):
         'voila_configuration': voila_configuration
     }
 
-    handlers =  [
+    handlers = [
         (r'/voila/render/(.*)', VoilaHandler, {
             'config': server_app.config,
             'template_paths': template_paths,

--- a/voila/server_extension.py
+++ b/voila/server_extension.py
@@ -9,18 +9,21 @@
 
 import os
 import gettext
+import tempfile
 
 from jinja2 import Environment, FileSystemLoader
 
 from jupyter_server.utils import url_path_join
 from jupyter_server.base.handlers import path_regex, FileFindHandler
+from jupyter_server.services.kernels.kernelmanager import MappingKernelManager
 
 from .paths import ROOT, collect_template_paths, collect_static_paths, jupyter_path
 from .handler import VoilaHandler
 from .treehandler import VoilaTreeHandler
 from .static_file_handler import MultiStaticFileHandler, WhiteListFileHandler
 from .configuration import VoilaConfiguration
-from .utils import get_server_root_dir
+from .utils import add_base_url_to_handlers, get_server_root_dir
+from .app import base_handlers
 
 
 def _jupyter_server_extension_paths():
@@ -51,23 +54,38 @@ def _load_jupyter_server_extension(server_app):
     nbui = gettext.translation('nbui', localedir=os.path.join(ROOT, 'i18n'), fallback=True)
     env.install_gettext_translations(nbui, newstyle=False)
 
+    connection_dir = tempfile.gettempdir()
+
+    kernel_mapping_manager = MappingKernelManager(
+        connection_dir=connection_dir,
+        allowed_message_types=[
+            'comm_msg',
+            'comm_info_request',
+            'kernel_info_request',
+            'custom_message',
+            'shutdown_request'
+        ]
+    )
+    web_app.settings['voila_kernel_manager'] = kernel_mapping_manager
+
     host_pattern = '.*$'
     base_url = url_path_join(web_app.settings['base_url'])
 
     tree_handler_conf = {
         'voila_configuration': voila_configuration
     }
-    web_app.add_handlers(host_pattern, [
-        (url_path_join(base_url, '/voila/render/(.*)'), VoilaHandler, {
+
+    handlers =  [
+        (r'/voila/render/(.*)', VoilaHandler, {
             'config': server_app.config,
             'template_paths': template_paths,
             'voila_configuration': voila_configuration
         }),
-        (url_path_join(base_url, '/voila'), VoilaTreeHandler, tree_handler_conf),
-        (url_path_join(base_url, '/voila/tree' + path_regex), VoilaTreeHandler, tree_handler_conf),
-        (url_path_join(base_url, '/voila/static/(.*)'), MultiStaticFileHandler, {'paths': static_paths}),
+        (r'/voila', VoilaTreeHandler, tree_handler_conf),
+        (r'/voila/tree' + path_regex, VoilaTreeHandler, tree_handler_conf),
+        (r'/voila/static/(.*)', MultiStaticFileHandler, {'paths': static_paths}),
         (
-            url_path_join(base_url, r'/voila/files/(.*)'),
+            r'/voila/files/(.*)',
             WhiteListFileHandler,
             {
                 'whitelist': voila_configuration.file_whitelist,
@@ -75,7 +93,7 @@ def _load_jupyter_server_extension(server_app):
                 'path': os.path.expanduser(get_server_root_dir(web_app.settings)),
             },
         ),
-    ])
+    ]
 
     # Serving notebook extensions
     if voila_configuration.enable_nbextensions:
@@ -86,10 +104,10 @@ def _load_jupyter_server_extension(server_app):
         else:
             nbextensions_path = jupyter_path('nbextensions')
 
-        web_app.add_handlers(host_pattern, [
+        handlers.extend([
             # this handler serves the nbextensions similar to the classical notebook
             (
-                url_path_join(base_url, r'/voila/nbextensions/(.*)'),
+                r'/voila/nbextensions/(.*)',
                 FileFindHandler,
                 {
                     'path': nbextensions_path,
@@ -97,6 +115,9 @@ def _load_jupyter_server_extension(server_app):
                 },
             )
         ])
+
+    handlers += base_handlers
+    web_app.add_handlers(host_pattern, add_base_url_to_handlers(base_url, handlers))
 
 
 # For backward compatibility

--- a/voila/utils.py
+++ b/voila/utils.py
@@ -1,4 +1,13 @@
+#############################################################################
+# Copyright (c) 2018, Voila Contributors                                    #
+#                                                                           #
+# Distributed under the terms of the BSD 3-Clause License.                  #
+#                                                                           #
+# The full license is in the file LICENSE, distributed with this software.  #
+#############################################################################
+
 import os
+from jupyter_server.utils import url_path_join
 
 
 def get_server_root_dir(settings):
@@ -15,3 +24,8 @@ def get_server_root_dir(settings):
         # collapse $HOME to ~
         root_dir = '~' + root_dir[len(home):]
     return root_dir
+
+
+def add_base_url_to_handlers(base_url, handlers):
+    """Adds the base_url in front of the urls in the Tornado handlers"""
+    return [tuple([url_path_join(base_url, url)] + list(tail)) for url, *tail in handlers]


### PR DESCRIPTION
Now voila and the server extension both use a voila_kernel_manager instead of kernel_manager. This means that voila used as server extension also does not allow arbitrary code execution.