### PR TITLE
Expose dir content to the VoilaHandler template

### DIFF
--- a/voila/handler.py
+++ b/voila/handler.py
@@ -59,11 +59,17 @@ class VoilaHandler(JupyterHandler):
             return
         self.cwd = os.path.dirname(notebook_path)
 
+        # Get path content
+        dir_path, notebook_name = os.path.split(notebook_path)
+        contents = self.contents_manager.get(dir_path)
+
         # render notebook to html
         resources = {
             'base_url': self.base_url,
             'nbextensions': nbextensions,
-            'theme': self.voila_configuration.theme
+            'theme': self.voila_configuration.theme,
+            'contents': contents,
+            'notebook_name': notebook_name
         }
 
         # include potential extra resources


### PR DESCRIPTION
This allows one to make a voila template with a tree view of the current directory:

This should fix #197

![voila_tree](https://user-images.githubusercontent.com/21197331/59031870-2b3cf380-8865-11e9-82b2-d7d2caed1788.png)

As discussed with @maartenbreddels, there might be better ways of doing this.