### PR TITLE
Switch templates via query string parameters

### DIFF
--- a/tests/app/template_url_test.py
+++ b/tests/app/template_url_test.py
@@ -1,0 +1,22 @@
+# tests selecting a template via query string parameters
+import pytest
+
+
+@pytest.fixture
+def voila_args(notebook_directory, voila_args_extra):
+    return ['--template=default', '--VoilaTest.root_dir=%r' % notebook_directory] + voila_args_extra
+
+
+@pytest.mark.gen_test
+def test_default_template(http_client, print_notebook_url):
+    response = yield http_client.fetch(print_notebook_url)
+    assert response.code == 200
+    assert 'theme-light.css' in response.body.decode('utf-8')
+
+
+@pytest.mark.gen_test
+def test_template_url_parameter(http_client, print_notebook_url):
+    url = print_notebook_url + "?template=test_template"
+    response = yield http_client.fetch(url)
+    assert response.code == 200
+    assert 'test_template.css' in response.body.decode('utf-8')

--- a/voila/app.py
+++ b/voila/app.py
@@ -337,8 +337,7 @@ class Voila(Application):
             collect_template_paths(
                 self.nbconvert_template_paths,
                 self.static_paths,
-                self.template_paths,
-                self.voila_configuration.template)
+                self.template_paths)
         self.log.debug('using template: %s', self.voila_configuration.template)
         self.log.debug('nbconvert template paths:\n\t%s', '\n\t'.join(self.nbconvert_template_paths))
         self.log.debug('template paths:\n\t%s', '\n\t'.join(self.template_paths))

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -68,12 +68,13 @@ class VoilaHandler(JupyterHandler):
         # choose the template
         template_name = (
             self.get_query_argument('template', '') or
-            self.voila_configuration.template or
-            'default'
+            self.voila_configuration.template
         )
 
-        # prioritize paths based on the template name
-        templates = sorted(self.nbconvert_template_paths, key=lambda p: -(template_name in p))
+        templates = self.nbconvert_template_paths
+        if self.voila_configuration.template:
+            # prioritize paths based on the template name if specified
+            templates = sorted(self.nbconvert_template_paths, key=lambda p: -(template_name in p))
 
         exporter = VoilaExporter(
             template_path=templates,

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -65,8 +65,18 @@ class VoilaHandler(JupyterHandler):
             'theme': self.voila_configuration.theme
         }
 
+        # choose the template
+        template_name = (
+            self.get_query_argument('template', '') or
+            self.voila_configuration.template or
+            'default'
+        )
+
+        # prioritize paths based on the template name
+        templates = sorted(self.nbconvert_template_paths, key=lambda p: -(template_name in p))
+
         exporter = VoilaExporter(
-            template_path=self.nbconvert_template_paths,
+            template_path=templates,
             config=self.exporter_config,
             contents_manager=self.contents_manager  # for the image inlining
         )

--- a/voila/paths.py
+++ b/voila/paths.py
@@ -7,7 +7,6 @@
 #############################################################################
 
 import os
-import json
 
 from jupyter_core.paths import jupyter_path
 
@@ -22,8 +21,7 @@ notebook_path_regex = r'(.*\.ipynb)'
 def collect_template_paths(
         nbconvert_template_paths,
         static_paths,
-        tornado_template_paths,
-        template_name='default'):
+        tornado_template_paths):
     """
     Voila supports custom templates for rendering notebooks.
 
@@ -46,25 +44,12 @@ def collect_template_paths(
         search_directories.append(os.path.abspath(os.path.join(ROOT, '..', 'share', 'jupyter', 'voila', 'templates')))
     search_directories.extend(jupyter_path('voila', 'templates'))
 
-    found_at_least_one = False
     for search_directory in search_directories:
-        template_directory = os.path.join(search_directory, template_name)
-        if os.path.exists(template_directory):
-            found_at_least_one = True
-            conf = {}
-            conf_file = os.path.join(template_directory, 'conf.json')
-            if os.path.exists(conf_file):
-                with open(conf_file) as f:
-                    conf = json.load(f)
+        if not os.path.exists(search_directory):
+            continue
 
-            # For templates that are not named 'default', we assume the default base_template is 'default'
-            # that means that even the default template could have a base_template when explicitly given.
-            if template_name != 'default' or 'base_template' in conf:
-                collect_template_paths(
-                    nbconvert_template_paths,
-                    static_paths,
-                    tornado_template_paths,
-                    conf.get('base_template', 'default'))
+        for template_name in os.listdir(search_directory):
+            template_directory = os.path.join(search_directory, template_name)
 
             extra_nbconvert_path = os.path.join(template_directory, 'nbconvert_templates')
             nbconvert_template_paths.insert(0, extra_nbconvert_path)
@@ -74,11 +59,3 @@ def collect_template_paths(
 
             extra_template_path = os.path.join(template_directory, 'templates')
             tornado_template_paths.insert(0, extra_template_path)
-
-            # We don't look at multiple directories, once a directory with a given name is found at a
-            # given level of precedence (for instance user directory), we don't look further (for instance
-            # in sys.prefix)
-            break
-    if not found_at_least_one:
-        paths = "\n\t".join(search_directories)
-        raise ValueError('No template sub-directory with name %r found in the following paths:\n\t%s' % (template_name, paths))

--- a/voila/server_extension.py
+++ b/voila/server_extension.py
@@ -34,8 +34,7 @@ def load_jupyter_server_extension(server_app):
     collect_template_paths(
         nbconvert_template_paths,
         static_paths,
-        template_paths,
-        voila_configuration.template
+        template_paths
     )
 
     jenv_opt = {"autoescape": True}


### PR DESCRIPTION
A proof of concept for switching templates on the fly via the notebook metadata and query string parameters.

Related to https://github.com/QuantStack/voila/issues/188 and https://github.com/QuantStack/voila/issues/105.

- ~Rename the cli parameter `template` to `templates` to pass a list of available templates (instead of a single one)~
- ~Fetch `template` from the notebook metadata~
- Fetch `template` from the query string parameters
- (tests are not fixed yet)

One thing I'm not super happy with is the need to sort the `nbconvert_template_paths` list before passing it to the nbconvert exporter.

Also this approach might be completely invalidated if / when the template mechanism is changed for the next release.

![template-url](https://user-images.githubusercontent.com/591645/59694306-b369b400-91e8-11e9-85ce-9d42e22a5ed2.gif)
