### PR TITLE
Don't include map files in distributions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -254,6 +254,7 @@ def get_data_files():
     # Add all the templates
     for (dirpath, dirnames, filenames) in os.walk('share/jupyter/voila/templates/'):
         if filenames:
+            filenames = [f for f in filenames if not f.endswith('.map')]
             data_files.append((dirpath, [os.path.join(dirpath, filename) for filename in filenames]))
     return data_files
 


### PR DESCRIPTION
This reduces the size of the `sdist` from `4.5M` to `1.3M` for me.

These files are quite useful during development but not needed by endusers.