### PR TITLE
Add docs for running voila on a private server

### DIFF
--- a/docs/source/deploy.rst
+++ b/docs/source/deploy.rst
@@ -349,7 +349,7 @@ Enable HTTPS with Let's Encrypt
 
 4. Visit https://yourdomain.com to access the voila applications over HTTPS.
 
-5. To automatically renew the certificates (they expire after 90 days), open the ``contrab`` file:
+5. To automatically renew the certificates (they expire after 90 days), open the ``crontab`` file:
 
     .. code :: text
 

--- a/docs/source/deploy.rst
+++ b/docs/source/deploy.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2018, Voila Contributors
    Copyright (c) 2018, QuantStack
-   
+
    Distributed under the terms of the BSD 3-Clause License.
-   
+
    The full license is in the file LICENSE, distributed with this software.
 
 ===============
@@ -315,6 +315,53 @@ You can edit the command to change this behavior and the notebooks voila is serv
 
 
 10. Now go to ``yourdomain.com`` to access the voila application.
+
+Enable HTTPS with Let's Encrypt
+-------------------------------
+
+1. Install ``certbot``:
+
+    .. code:: text
+
+        sudo add-apt-repository ppa:certbot/certbot
+        sudo apt update
+        sudo apt install python-certbot-nginx
+
+2. Obtain the certificates from Let's Encrypt. The ``--nginx`` flag will edit the nginx configuration automatically:
+
+    .. code:: text
+
+        sudo certbot --nginx -d yourdomain.com
+
+3. ``/etc/nginx/sites-enabled/yourdomain.com`` should now contain a few more entries:
+
+    .. code :: text
+
+        $ cat /etc/nginx/sites-enabled/yourdomain.com
+
+        ...
+        listen 443 ssl; # managed by Certbot
+        ssl_certificate /etc/letsencrypt/live/yourdomain.com/fullchain.pem; # managed by Certbot
+        ssl_certificate_key /etc/letsencrypt/live/yourdomain.com/privkey.pem; # managed by Certbot
+        include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+        ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+        ...
+
+4. Visit https://yourdomain.com to access the voila applications over HTTPS.
+
+5. To automatically renew the certificates (they expire after 90 days), open the ``contrab`` file:
+
+    .. code :: text
+
+        crontab -e
+
+And add the following line:
+
+    .. code :: text
+
+        0 12 * * * /usr/bin/certbot renew --quiet
+
+For more information, you can also follow `the guide on the nginx blog <https://www.nginx.com/blog/using-free-ssltls-certificates-from-lets-encrypt-with-nginx/>`__.
 
 Sharing Voilà applications with ngrok
 =====================================

--- a/docs/source/deploy.rst
+++ b/docs/source/deploy.rst
@@ -270,7 +270,7 @@ Steps
 
         sudo apt update && sudo apt install python3-pip
 
-7. Install the dependencies for running voila applications:
+7. Follow the instructions in `Setup an example project`_, and install the dependencies:
 
     .. code:: text
 


### PR DESCRIPTION
Add documentation to deploy voila on a private server behind nginx, as a follow-up for the [question asked on gitter](https://gitter.im/QuantStack/Lobby?at=5d5bcd6f7d56bc60808d5f00).
