### PR TITLE
Load template-related config from JSON file.

### DIFF
--- a/tests/app/template_config_file_test.py
+++ b/tests/app/template_config_file_test.py
@@ -1,0 +1,22 @@
+# tests config of template sytem from JSON file
+import pytest
+
+import os
+
+BASE_DIR = os.path.dirname(__file__)
+
+
+@pytest.fixture
+def voila_args_extra():
+    path_test_template = os.path.abspath(os.path.join(BASE_DIR, '../test_template/share/jupyter/voila/templates/test_template/nbconvert_templates'))
+    path_default = os.path.abspath(os.path.join(BASE_DIR, '../../share/jupyter/voila/templates/default/nbconvert_templates'))
+    return ['--template=test_template', '--Voila.nbconvert_template_paths=[%r, %r]' % (path_test_template, path_default)]
+
+
+@pytest.mark.gen_test
+def test_template_test(http_client, base_url):
+    response = yield http_client.fetch(base_url)
+    assert response.code == 200
+    assert 'test_template.css' in response.body.decode('utf-8')
+    assert 'Hi Voila' in response.body.decode('utf-8')
+    assert 'default value' in response.body.decode('utf-8')

--- a/tests/app/template_config_file_test.py
+++ b/tests/app/template_config_file_test.py
@@ -19,4 +19,4 @@ def test_template_test(http_client, base_url):
     assert response.code == 200
     assert 'test_template.css' in response.body.decode('utf-8')
     assert 'Hi Voila' in response.body.decode('utf-8')
-    assert 'default value' in response.body.decode('utf-8')
+    assert 'test resource from config file' in response.body.decode('utf-8')

--- a/tests/test_template/share/jupyter/voila/templates/test_template/conf.json
+++ b/tests/test_template/share/jupyter/voila/templates/test_template/conf.json
@@ -1,0 +1,10 @@
+{
+  "traitlet_configuration": {
+    "base_template": "test_template",
+    "resources": {
+      "test_template": {
+        "test_resource": "test resource from config file"
+      }
+    }
+  }
+}

--- a/tests/test_template/share/jupyter/voila/templates/test_template/nbconvert_templates/voila.tpl
+++ b/tests/test_template/share/jupyter/voila/templates/test_template/nbconvert_templates/voila.tpl
@@ -3,6 +3,8 @@ This is a test template, obviously
 
 <link rel="stylesheet" type="text/css" href="test_template.css"></link>
 
+Print value of extra resource for test template:
+{{resources.test_template.test_resource | default('default value', true)}}
 
 List extensions:
 {% for ext in resources.nbextensions -%}

--- a/voila/app.py
+++ b/voila/app.py
@@ -40,10 +40,9 @@ from traitlets import Unicode, Integer, Bool, Dict, List, default
 from jupyter_server.services.kernels.kernelmanager import MappingKernelManager
 from jupyter_server.services.kernels.handlers import KernelHandler, ZMQChannelsHandler
 from jupyter_server.services.contents.largefilemanager import LargeFileManager
-from jupyter_server.base.handlers import path_regex
+from jupyter_server.base.handlers import FileFindHandler, path_regex
 from jupyter_server.utils import url_path_join
 from jupyter_server.services.config import ConfigManager
-from jupyter_server.base.handlers import FileFindHandler
 
 from jupyter_client.kernelspec import KernelSpecManager
 
@@ -341,8 +340,6 @@ class Voila(Application):
 
         # then we load the config
         self.load_config_file('voila', path=self.config_file_paths)
-        # but that cli config has preference, so we overwrite with that
-        self.update_config(self.cli_config)
         # common configuration options between the server extension and the application
         self.voila_configuration = VoilaConfiguration(parent=self)
         self.setup_template_dirs()
@@ -480,13 +477,15 @@ class Voila(Application):
             self.log.debug('serving directory: %r', self.root_dir)
             handlers.extend([
                 (self.server_url, VoilaTreeHandler, tree_handler_conf),
-                (url_path_join(self.server_url, r'/voila/tree' + path_regex), VoilaTreeHandler, tree_handler_conf),
-                (url_path_join(self.server_url, r'/voila/render/(.*)'), VoilaHandler,
-                    {
-                        'nbconvert_template_paths': self.nbconvert_template_paths,
-                        'config': self.config,
-                        'voila_configuration': self.voila_configuration
-                    }),
+                (url_path_join(self.server_url, r'/voila/tree' + path_regex),
+                 VoilaTreeHandler, tree_handler_conf),
+                (url_path_join(self.server_url, r'/voila/render/(.*)'),
+                 VoilaHandler,
+                 {
+                     'nbconvert_template_paths': self.nbconvert_template_paths,
+                     'config': self.config,
+                     'voila_configuration': self.voila_configuration
+                 }),
             ])
 
         self.app.add_handlers('.*$', handlers)

--- a/voila/app.py
+++ b/voila/app.py
@@ -357,21 +357,19 @@ class Voila(Application):
             template_conf_dir = [os.path.join(k, '..') for k in self.nbconvert_template_paths]
             conf_paths = [os.path.join(d, 'conf.json') for d in template_conf_dir]
             for p in conf_paths:
-                # see if config path corresponds to template in use
-                if os.path.basename(os.path.dirname(p)) == self.voila_configuration.template:
-                    # see if config file exists
-                    if os.path.exists(p):
-                        # load the template-related config
-                        loader = JSONFileConfigLoader('conf.json', template_conf_dir)
-                        conf = loader.load_config()
-                        # check that config file is meant for template in use
-                        assert conf.traitlet_configuration['base_template'] == self.voila_configuration.template
-                        # create sub-config as Config instance for merging (see next)
-                        conf.VoilaConfiguration = Config(conf.traitlet_configuration)
-                        # merge config from file with otherwise voila config, ensuring CLI config priority
-                        conf.merge(self.voila_configuration.config)
-                        # pass merged config to overall voila config
-                        self.voila_configuration.config.VoilaConfiguration = conf.VoilaConfiguration
+                # see if config file exists
+                if os.path.exists(p):
+                    # load the template-related config
+                    loader = JSONFileConfigLoader('conf.json', template_conf_dir)
+                    conf = loader.load_config()
+                    # check that config file is meant for template in use
+                    assert conf.traitlet_configuration['base_template'] == self.voila_configuration.template
+                    # create sub-config as Config instance for merging (see next)
+                    conf.VoilaConfiguration = Config(conf.traitlet_configuration)
+                    # merge config from file with otherwise voila config, ensuring CLI config priority
+                    conf.merge(self.voila_configuration.config)
+                    # pass merged config to overall voila config
+                    self.voila_configuration.config.VoilaConfiguration = conf.VoilaConfiguration
         self.log.debug('using template: %s', self.voila_configuration.template)
         self.log.debug('nbconvert template paths:\n\t%s', '\n\t'.join(self.nbconvert_template_paths))
         self.log.debug('template paths:\n\t%s', '\n\t'.join(self.template_paths))

--- a/voila/app.py
+++ b/voila/app.py
@@ -11,6 +11,7 @@ from zmq.eventloop import ioloop
 
 import gettext
 import io
+import json
 import logging
 import threading
 import tempfile
@@ -35,13 +36,14 @@ import tornado.ioloop
 import tornado.web
 
 from traitlets.config.application import Application
-from traitlets.config.loader import Config, JSONFileConfigLoader
+from traitlets.config.loader import Config
 from traitlets import Unicode, Integer, Bool, Dict, List, default
 
 from jupyter_server.services.kernels.kernelmanager import MappingKernelManager
 from jupyter_server.services.kernels.handlers import KernelHandler, ZMQChannelsHandler
 from jupyter_server.services.contents.largefilemanager import LargeFileManager
 from jupyter_server.base.handlers import FileFindHandler, path_regex
+from jupyter_server.config_manager import recursive_update
 from jupyter_server.utils import url_path_join
 from jupyter_server.services.config import ConfigManager
 
@@ -360,16 +362,14 @@ class Voila(Application):
                 # see if config file exists
                 if os.path.exists(p):
                     # load the template-related config
-                    loader = JSONFileConfigLoader('conf.json', template_conf_dir)
-                    conf = loader.load_config()
+                    with open(p) as json_file:
+                        conf = json.load(json_file)
                     # check that config file is meant for template in use
-                    assert conf.traitlet_configuration['base_template'] == self.voila_configuration.template
-                    # create sub-config as Config instance for merging (see next)
-                    conf.VoilaConfiguration = Config(conf.traitlet_configuration)
-                    # merge config from file with otherwise voila config, ensuring CLI config priority
-                    conf.merge(self.voila_configuration.config)
+                    assert conf['traitlet_configuration']['base_template'] == self.voila_configuration.template
+                    # update the overall config with it, preserving CLI config priority
+                    recursive_update(conf['traitlet_configuration'], self.voila_configuration.config.VoilaConfiguration)
                     # pass merged config to overall voila config
-                    self.voila_configuration.config.VoilaConfiguration = conf.VoilaConfiguration
+                    self.voila_configuration.config.VoilaConfiguration = Config(conf['traitlet_configuration'])
         self.log.debug('using template: %s', self.voila_configuration.template)
         self.log.debug('nbconvert template paths:\n\t%s', '\n\t'.join(self.nbconvert_template_paths))
         self.log.debug('template paths:\n\t%s', '\n\t'.join(self.template_paths))

--- a/voila/app.py
+++ b/voila/app.py
@@ -354,7 +354,7 @@ class Voila(Application):
                 self.template_paths,
                 self.voila_configuration.template)
             # look for possible template-related config files
-            template_conf_dir = [os.path.dirname(k) for k in self.nbconvert_template_paths]
+            template_conf_dir = [os.path.join(k, '..') for k in self.nbconvert_template_paths]
             conf_paths = [os.path.join(d, 'conf.json') for d in template_conf_dir]
             for p in conf_paths:
                 # see if config path corresponds to template in use

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -77,7 +77,9 @@ class VoilaHandler(JupyterHandler):
         }
 
         # include potential extra resources
-        extra_resources = self.voila_configuration.resources
+        extra_resources = self.voila_configuration.config.VoilaConfiguration.resources
+        if not isinstance(extra_resources, dict):
+            extra_resources = extra_resources.to_dict()
         if extra_resources:
             recursive_update(resources, extra_resources)
 

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -78,6 +78,8 @@ class VoilaHandler(JupyterHandler):
 
         # include potential extra resources
         extra_resources = self.voila_configuration.config.VoilaConfiguration.resources
+        # if no resources get configured from neither the CLI nor a config file,
+        # extra_resources is a traitlets.config.loader.LazyConfigValue object
         if not isinstance(extra_resources, dict):
             extra_resources = extra_resources.to_dict()
         if extra_resources:


### PR DESCRIPTION
Check this out, @maartenbreddels!

It's basically a cleaner version of #326 (which I will close). Still missing a test or two though...

I have used `os.path.dirname` to go one directory up.

Here, we are not simply reading whatever `conf.json` file we may find in a list of template paths, we are ensuring it corresponds to the template being used.

Demo style:

* if no `conf.json` file lives in `PREFIX/share/jupyter/voila/templates/reveal`, then running
```
$ voila reveal.ipynb --template=reveal
```
will launch a slideshow where transitions slide (because `'slide'` is the default, as set in the reveal template);

* if this `conf.json` [file](https://github.com/QuantStack/voila/pull/326#issuecomment-526417088) lives in `PREFIX/share/jupyter/voila/templates/reveal`, then running
```
$ voila reveal.ipynb --template=reveal
```
will launch a slideshow where transitions zoom, because this config file is well-formed and says `"transition": "zoom"`;

* if this `conf.json` [file](https://github.com/QuantStack/voila/pull/326#issuecomment-526417088) lives in `PREFIX/share/jupyter/voila/templates/reveal`, then running
```
$ voila reveal.ipynb --template=reveal --VoilaConfiguration.resources="{'reveal': {'transition': 'fade'}}"
```
will launch a slideshow where transitions fade, because CLI config has preference; if `conf.json` specified a non-default resource (e.g., `"scroll": true`), it wouldn't be taken into account, unfortunately, because traitlets' Config [merge](https://github.com/ipython/traitlets/blob/41551bc8b30ccc28af738e93615e3408cb94d5d3/traitlets/config/loader.py#L190) is not recursive...

If we really wanted to merge all template-related configs recursively, always ensuring CLI priority, we would need to have the convoluted approach I had in #326.

The little contortions I had to do in `handler.py` come from covering all cases, e.g., for
```
$ voila reveal.ipynb --template=reveal --VoilaConfiguration.resources="{'reveal': {'transition': 'fade'}}"
```
to run regardless, with or without a config file somewhere. And all the config merging and passing around happening in `app.py` leads to the fact that: a) we need to get to `self.voila_configuration.config.VoilaConfiguration.resources` to find those extra resources (so painfully retrieved and combined) and b) `self.voila_configuration.config.VoilaConfiguration.resources` ends up being of type `traitlets.config.loader.LazyConfigValue` when neither a file nor CLI config passes extra resources (maybe I could prevent this by setting `self.voila_configuration.config.VoilaConfiguration.resources = {}` ahead of time in `app.py`).