### PR TITLE
Speed up progressive rendering

### DIFF
--- a/voila/execute.py
+++ b/voila/execute.py
@@ -107,6 +107,14 @@ class VoilaExecutePreprocessor(ExecutePreprocessor):
             result = (nb, resources)
         return result
 
+    def preprocess_cell(self, cell, resources, cell_index, store_history=True):
+        try:
+            result = super(VoilaExecutePreprocessor, self).preprocess_cell(cell, resources, cell_index, store_history)
+        except CellExecutionError as e:
+            self.log.error(e)
+            result = [cell]
+        return result
+
     def register_output_hook(self, msg_id, hook):
         # mimics
         # https://jupyterlab.github.io/jupyterlab/services/interfaces/kernel.ikernelconnection.html#registermessagehook

--- a/voila/execute.py
+++ b/voila/execute.py
@@ -94,9 +94,12 @@ class OutputWidget:
 
 class VoilaExecutePreprocessor(ExecutePreprocessor):
     """Execute, but respect the output widget behaviour"""
-    def preprocess(self, nb, resources, km=None):
+    def __init__(self, **kwargs):
+        super(VoilaExecutePreprocessor, self).__init__(**kwargs)
         self.output_hook_stack = collections.defaultdict(list)  # maps to list of hooks, where the last is used
         self.output_objects = {}
+
+    def preprocess(self, nb, resources, km=None):
         try:
             result = super(VoilaExecutePreprocessor, self).preprocess(nb, resources=resources, km=km)
         except CellExecutionError as e:


### PR DESCRIPTION
Should fix #395 

Instead of using the `preprocess` method (which is for preprocessing an entire Notebook) for each cell, I use `preprocess_cell` for each cell

![speedup](https://user-images.githubusercontent.com/21197331/66118244-294a2d80-e5d6-11e9-8f99-c732a3b32e70.gif)
