### PR TITLE
feat: execute cells in a thread, this will unblock the server's event loop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
  - osx
 env:
  matrix:
-  - PYTHON_VERSION=2.7
+  - PYTHON_VERSION=3.5
   - PYTHON_VERSION=3.6
   - PYTHON_VERSION=3.7
 before_install:
@@ -18,12 +18,12 @@ before_install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - conda create -q -n test-environment -c conda-forge python=$PYTHON_VERSION jupyter_server==0.1.0 jupyterlab_pygments==0.1.0 pytest==3.10.1 nbconvert=5.6 pytest-cov nodejs flake8 ipywidgets matplotlib xeus-cling
+  - conda create -q -n test-environment -c conda-forge python=$PYTHON_VERSION jupyterlab_pygments==0.1.0 nbconvert=5.5 pytest-cov nodejs flake8 ipywidgets matplotlib xeus-cling
   - source activate test-environment
 install:
   - pip install ".[test]"
   - cd tests/test_template; pip install .; cd ../../;
-before_script:
+after_script:
   - flake8 voila tests setup.py
 script:
   - VOILA_TEST_DEBUG=1 VOILA_TEST_XEUS_CLING=1 py.test tests/ --async-test-timeout=240

--- a/setup.py
+++ b/setup.py
@@ -375,6 +375,7 @@ setup_args = {
         ]
     },
     'install_requires': [
+        'async_generator',
         'jupyter_server>=0.1.0,<0.2.0',
         'nbconvert>=5.6.0,<6',
         'jupyterlab_pygments>=0.1.0,<0.2',

--- a/voila/exporter.py
+++ b/voila/exporter.py
@@ -19,6 +19,12 @@ from nbconvert.exporters.html import HTMLExporter
 from nbconvert.exporters.templateexporter import TemplateExporter
 from nbconvert.filters.highlight import Highlight2HTML
 
+from .threading import async_generator_to_thread
+
+# As long as we support Python35, we use this library to get as async
+# generators: https://pypi.org/project/async_generator/
+from async_generator import async_generator, yield_
+
 
 class VoilaMarkdownRenderer(IPythonRenderer):
     """Custom markdown renderer that inlines images"""
@@ -77,7 +83,8 @@ class VoilaExporter(HTMLExporter):
     def default_template_file(self):
         return 'voila.tpl'
 
-    def generate_from_notebook_node(self, nb, resources=None, extra_context={}, **kw):
+    @async_generator
+    async def generate_from_notebook_node(self, nb, resources=None, extra_context={}, **kw):
         # this replaces from_notebook_node, but calls template.generate instead of template.render
         langinfo = nb.metadata.get('language_info', {})
         lexer = langinfo.get('pygments_lexer', langinfo.get('name', None))
@@ -99,9 +106,21 @@ class VoilaExporter(HTMLExporter):
                 'no_prompt': self.exclude_input_prompt and self.exclude_output_prompt,
                 }
 
-        # Top level variables are passed to the template_exporter here.
-        for output in self.template.generate(nb=nb_copy, resources=resources, **extra_context):
-            yield output, resources
+        # Jinja with Python3.5 does not support async (generators), which
+        # means that it's not async all the way down. Which means that we
+        # cannot use coroutines for the cell_generator, and that they will
+        # block the IO loop. In that case we will run the iterator in a
+        # thread instead.
+
+        @async_generator_to_thread
+        @async_generator
+        async def async_jinja_generator():
+            # Top level variables are passed to the template_exporter here.
+            for output in self.template.generate(nb=nb_copy, resources=resources, **extra_context):
+                await yield_((output, resources))
+
+        async for output, resources in async_jinja_generator():
+            await yield_((output, resources))
 
     @property
     def environment(self):

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -33,8 +33,7 @@ class VoilaHandler(JupyterHandler):
         self.kernel_started = False
 
     @tornado.web.authenticated
-    @tornado.gen.coroutine
-    def get(self, path=None):
+    async def get(self, path=None):
         # if the handler got a notebook_path argument, always serve that
         notebook_path = self.notebook_path or path
         if self.notebook_path and path:  # when we are in single notebook mode but have a path
@@ -55,7 +54,7 @@ class VoilaHandler(JupyterHandler):
         else:
             nbextensions = []
 
-        self.notebook = yield self.load_notebook(notebook_path)
+        self.notebook = await self.load_notebook(notebook_path)
         if not self.notebook:
             return
         self.cwd = os.path.dirname(notebook_path)
@@ -97,13 +96,17 @@ class VoilaHandler(JupyterHandler):
             'notebook_execute': self._jinja_notebook_execute,
         }
 
+        # Currenly _jinja_kernel_start is executed from a different thread, which causes the websocket connection from
+        # the frontend to fail. Instead, we start it beforehand, and just return the kernel_id in _jinja_kernel_start
+        self.kernel_id = await tornado.gen.maybe_future(self.kernel_manager.start_kernel(kernel_name=self.notebook.metadata.kernelspec.name, path=self.cwd))
+
         # Compose reply
         self.set_header('Content-Type', 'text/html')
         # render notebook in snippets, and flush them out to the browser can render progresssively
-        for html_snippet, resources in self.exporter.generate_from_notebook_node(self.notebook, resources=resources, extra_context=extra_context):
+        async for html_snippet, resources in self.exporter.generate_from_notebook_node(self.notebook, resources=resources, extra_context=extra_context):
             self.write(html_snippet)
             self.flush()  # we may not want to consider not flusing after each snippet, but add an explicit flush function to the jinja context
-            yield  # give control back to tornado's IO loop, so it can handle static files or other requests
+            # yield  # give control back to tornado's IO loop, so it can handle static files or other requests
         self.flush()
 
     def redirect_to_file(self, path):
@@ -112,10 +115,9 @@ class VoilaHandler(JupyterHandler):
     @tornado.gen.coroutine
     def _jinja_kernel_start(self):
         assert not self.kernel_started, "kernel was already started"
-        # Launch kernel
-        kernel_id = yield tornado.gen.maybe_future(self.kernel_manager.start_kernel(kernel_name=self.notebook.metadata.kernelspec.name, path=self.cwd))
+        # See command above aboout not being able to start the kernel from a different thread
         self.kernel_started = True
-        raise tornado.gen.Return(kernel_id)
+        return self.kernel_id
 
     def _jinja_notebook_execute(self, nb, kernel_id):
         km = self.kernel_manager.get_kernel(kernel_id)
@@ -138,26 +140,25 @@ class VoilaHandler(JupyterHandler):
 
                 yield res[0]
 
-    @tornado.gen.coroutine
-    def load_notebook(self, path):
+    # @tornado.gen.coroutine
+    async def load_notebook(self, path):
         model = self.contents_manager.get(path=path)
         if 'content' not in model:
             raise tornado.web.HTTPError(404, 'file not found')
         __, extension = os.path.splitext(model.get('path', ''))
         if model.get('type') == 'notebook':
             notebook = model['content']
-            notebook = yield self.fix_notebook(notebook)
-            raise tornado.gen.Return(notebook)  # TODO py2: replace by return
+            notebook = await self.fix_notebook(notebook)
+            return notebook
         elif extension in self.voila_configuration.extension_language_mapping:
             language = self.voila_configuration.extension_language_mapping[extension]
-            notebook = yield self.create_notebook(model, language=language)
-            raise tornado.gen.Return(notebook)  # TODO py2: replace by return
+            notebook = await self.create_notebook(model, language=language)
+            return notebook
         else:
             self.redirect_to_file(path)
-            raise tornado.gen.Return(None)
+            return None
 
-    @tornado.gen.coroutine
-    def fix_notebook(self, notebook):
+    async def fix_notebook(self, notebook):
         """Returns a notebook object with a valid kernelspec.
 
         In case the kernel is not found, we search for a matching kernel based on the language.
@@ -169,22 +170,21 @@ class VoilaHandler(JupyterHandler):
         kernelspec = notebook.metadata.kernelspec
         kernel_name = kernelspec.get('name', self.kernel_manager.default_kernel_name)
         # We use `maybe_future` to support RemoteKernelSpecManager
-        all_kernel_specs = yield tornado.gen.maybe_future(self.kernel_spec_manager.get_all_specs())
+        all_kernel_specs = await tornado.gen.maybe_future(self.kernel_spec_manager.get_all_specs())
         # Find a spec matching the language if the kernel name does not exist in the kernelspecs
         if kernel_name not in all_kernel_specs:
             missing_kernel_name = kernel_name
-            kernel_name = yield self.find_kernel_name_for_language(kernelspec.language.lower(), kernel_specs=all_kernel_specs)
+            kernel_name = await self.find_kernel_name_for_language(kernelspec.language.lower(), kernel_specs=all_kernel_specs)
             self.log.warning('Could not find a kernel named %r, will use  %r', missing_kernel_name, kernel_name)
         # We make sure the notebook's kernelspec is correct
         notebook.metadata.kernelspec.name = kernel_name
         notebook.metadata.kernelspec.display_name = all_kernel_specs[kernel_name]['spec']['display_name']
         notebook.metadata.kernelspec.language = all_kernel_specs[kernel_name]['spec']['language']
-        raise tornado.gen.Return(notebook)  # TODO py2: replace by return
+        return notebook
 
-    @tornado.gen.coroutine
-    def create_notebook(self, model, language):
-        all_kernel_specs = yield tornado.gen.maybe_future(self.kernel_spec_manager.get_all_specs())
-        kernel_name = yield self.find_kernel_name_for_language(language, kernel_specs=all_kernel_specs)
+    async def create_notebook(self, model, language):
+        all_kernel_specs = await tornado.gen.maybe_future(self.kernel_spec_manager.get_all_specs())
+        kernel_name = await self.find_kernel_name_for_language(language, kernel_specs=all_kernel_specs)
         spec = all_kernel_specs[kernel_name]
         notebook = nbformat.v4.new_notebook(
             metadata={
@@ -196,18 +196,17 @@ class VoilaHandler(JupyterHandler):
             },
             cells=[nbformat.v4.new_code_cell(model['content'])],
         )
-        raise tornado.gen.Return(notebook)  # TODO py2: replace by return
+        return notebook
 
-    @tornado.gen.coroutine
-    def find_kernel_name_for_language(self, kernel_language, kernel_specs=None):
+    async def find_kernel_name_for_language(self, kernel_language, kernel_specs=None):
         """Finds a best matching kernel name given a kernel language.
 
         If multiple kernels matches are found, we try to return the same kernel name each time.
         """
         if kernel_language in self.voila_configuration.language_kernel_mapping:
-            raise tornado.gen.Return(self.voila_configuration.language_kernel_mapping[kernel_language])  # TODO py2: replace by return
+            return self.voila_configuration.language_kernel_mapping[kernel_language]
         if kernel_specs is None:
-            kernel_specs = yield tornado.gen.maybe_future(self.kernel_spec_manager.get_all_specs())
+            kernel_specs = await tornado.gen.maybe_future(self.kernel_spec_manager.get_all_specs())
         matches = [
             name for name, kernel in kernel_specs.items()
             if kernel["spec"]["language"].lower() == kernel_language.lower()
@@ -215,6 +214,6 @@ class VoilaHandler(JupyterHandler):
         if matches:
             # Sort by display name to get the same kernel each time.
             matches.sort(key=lambda name: kernel_specs[name]["spec"]["display_name"])
-            raise tornado.gen.Return(matches[0])  # TODO py2: replace by return
+            return matches[0]
         else:
             raise tornado.web.HTTPError(500, 'No Jupyter kernel for language %r found' % kernel_language)

--- a/voila/threading.py
+++ b/voila/threading.py
@@ -1,0 +1,53 @@
+import asyncio
+import concurrent.futures
+import inspect
+import threading
+import tornado.queues
+
+# As long as we support Python35, we use this library to get as async
+# generators: https://pypi.org/project/async_generator/
+from async_generator import async_generator, yield_
+
+
+class ThreadedAsyncGenerator(threading.Thread):
+    def __init__(self, main_ioloop, fn, *args, **kwargs):
+        super(ThreadedAsyncGenerator, self).__init__()
+        self.main_ioloop = main_ioloop
+        self.fn = fn
+        self.args = args
+        self.kwargs = kwargs
+        self.queue = tornado.queues.Queue()
+        self.start()
+
+    def run(self):
+        ioloop_in_thread = asyncio.new_event_loop()
+        asyncio.set_event_loop(ioloop_in_thread)
+        return ioloop_in_thread.run_until_complete(self._run())
+
+    async def _run(self):
+        async for item in self.fn(*self.args, **self.kwargs):
+            def thread_safe_put(item=item):
+                self.queue.put(item)
+            self.main_ioloop.call_soon_threadsafe(thread_safe_put)
+
+        def thread_safe_end():
+            self.queue.put(StopIteration)
+        self.main_ioloop.call_soon_threadsafe(thread_safe_end)
+
+    @async_generator
+    async def __aiter__(self):
+        while True:
+            value = await self.queue.get()
+            if value == StopIteration:
+                break
+            await yield_(value)
+
+
+def async_generator_to_thread(fn):
+    """Calls an async generator function fn in a thread and async returns the results"""
+    ioloop = asyncio.get_event_loop()
+
+    def wrapper(*args, **kwargs):
+        gen = ThreadedAsyncGenerator(ioloop, fn, *args, **kwargs)
+        return gen
+    return wrapper


### PR DESCRIPTION
BREAKING refactor: use native coroutines instead of tornado's

This is a simpler version of #374

TODO: 
 * [x] drop py27 in travis, add py35
 * [x] handle exceptions in thread.