### PR TITLE
Expose base_url to browser-open template

### DIFF
--- a/voila/app.py
+++ b/voila/app.py
@@ -524,7 +524,7 @@ class Voila(Application):
 
             jinja2_env = self.app.settings['jinja2_env']
             template = jinja2_env.get_template('browser-open.html')
-            fh.write(template.render(open_url=url))
+            fh.write(template.render(open_url=url, base_url=url))
 
         def target():
             return browser.open(urljoin('file:', pathname2url(open_file)), new=self.webbrowser_open_new)


### PR DESCRIPTION
This is for homogeneity with other template files under the "templates/" directory. It allows having the same base template accessing the same assets under the static directory.

For example, when having a `base.html` file like this:
```html
<!DOCTYPE html>
<html>
  <head>
    <link rel="stylesheet" href="{{base_url}}voila/static/style.min.css">
  </head>

  <body>
    {% block body %}
    {% endblock %}
    
    <script src="{{base_url}}voila/static/javascript.min.js"></script>
  </body>
</html>
```

We can now make the `browser-open.html` and the `404.html` template inherit from the same `base.html` template.

This is backward incompatible for other templates out there.