### PR TITLE
Passing request URI to kernel env

### DIFF
--- a/notebooks/query-strings.ipynb
+++ b/notebooks/query-strings.ipynb
@@ -1,0 +1,107 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-08-18T12:06:29.243603Z",
+     "start_time": "2020-08-18T12:06:29.240780Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from urllib.parse import parse_qs\n",
+    "import IPython.display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-08-18T12:06:29.250356Z",
+     "start_time": "2020-08-18T12:06:29.246161Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "query_string = os.environ.get('QUERY_STRING', '')\n",
+    "parameters = parse_qs(query_string)\n",
+    "print(\"query string parameters:\", parameters)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-08-18T12:06:29.258506Z",
+     "start_time": "2020-08-18T12:06:29.253815Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# parameters is a dict of lists\n",
+    "username = parameters.get('username', ['Kim'])[0]\n",
+    "print(f'Hi {username}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-08-18T12:06:29.275717Z",
+     "start_time": "2020-08-18T12:06:29.261315Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "server = os.environ.get('SERVER_NAME', 'localhost') \n",
+    "url = \"http://\" + server\n",
+    "\n",
+    "port = os.environ.get('SERVER_PORT', '')\n",
+    "if port:\n",
+    "    url += \":\" + port\n",
+    "\n",
+    "path = os.environ.get('SCRIPT_NAME', '')\n",
+    "url += path\n",
+    "\n",
+    "                          \n",
+    "IPython.display.HTML(data=f\"\"\"\n",
+    "<a href=\"{url}?username=Riley\">Link to myself as user Riley</a>\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tests/app/cgi-test.py
+++ b/tests/app/cgi-test.py
@@ -1,0 +1,17 @@
+import pytest
+
+
+@pytest.fixture
+def notebook_cgi_path(base_url):
+    return base_url + "voila/render/cgi.ipynb"
+
+
+@pytest.fixture
+def voila_args(notebook_directory, voila_args_extra):
+    return ['--VoilaTest.root_dir=%r' % notebook_directory, '--VoilaTest.log_level=DEBUG'] + voila_args_extra
+
+
+async def test_cgi_using_query_parameters(capsys, http_server_client, notebook_cgi_path):
+    response = await http_server_client.fetch(notebook_cgi_path + '?username=VOILA')
+    assert response.code == 200
+    assert 'VOILA' in response.body.decode('utf-8')

--- a/tests/notebooks/cgi.ipynb
+++ b/tests/notebooks/cgi.ipynb
@@ -1,0 +1,56 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-08-18T11:55:18.544213Z",
+     "start_time": "2020-08-18T11:55:18.541029Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from urllib.parse import parse_qs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-08-18T11:55:19.281230Z",
+     "start_time": "2020-08-18T11:55:19.278088Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "query_string = os.environ.get('QUERY_STRING', '')\n",
+    "parameters = parse_qs(query_string)\n",
+    "print(\"query string parameters:\", parameters)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -18,7 +18,9 @@ import nbformat
 
 from nbconvert.preprocessors import ClearOutputPreprocessor
 from nbclient.util import ensure_async
+from tornado.httputil import split_host_and_port
 
+from ._version import __version__
 from .execute import VoilaExecutor
 from .exporter import VoilaExporter
 
@@ -62,6 +64,17 @@ class VoilaHandler(JupyterHandler):
 
         path, basename = os.path.split(notebook_path)
         notebook_name = os.path.splitext(basename)[0]
+
+        # Adding request uri to kernel env
+        self.kernel_env = os.environ.copy()
+        self.kernel_env['SCRIPT_NAME'] = self.request.path
+        self.kernel_env['PATH_INFO'] = ''  # would be /foo/bar if voila.ipynb/foo/bar was supported
+        self.kernel_env['QUERY_STRING'] = str(self.request.query)
+        self.kernel_env['SERVER_SOFTWARE'] = 'voila/{}'.format(__version__)
+        self.kernel_env['SERVER_PROTOCOL'] = str(self.request.version)
+        host, port = split_host_and_port(self.request.host.lower())
+        self.kernel_env['SERVER_PORT'] = str(port) if port else ''
+        self.kernel_env['SERVER_NAME'] = host
 
         # render notebook to html
         resources = {
@@ -121,7 +134,8 @@ class VoilaHandler(JupyterHandler):
 
         kernel_id = await ensure_async(self.kernel_manager.start_kernel(
            kernel_name=nb.metadata.kernelspec.name,
-           path=self.cwd
+           path=self.cwd,
+           env=self.kernel_env,
         ))
         km = self.kernel_manager.get_kernel(kernel_id)
 


### PR DESCRIPTION
**Issue**: https://github.com/voila-dashboards/voila/issues/410

POC of ability to pass request uri into kernel. This would enable all sorts of dynamic/linking dashboard setups.

Added a sample notebook that prints the env.

**Concerns:**
When the kernel manager starts a new kernel, it either uses the existing environment or an environment passed in as an argument. It does not merge these environments. This is a concern if there was anything in the previous `os.environ` that we needed.

https://github.com/jupyter/jupyter_client/blob/dc213de1b5cc7b5c28485ae799fecfef77589a85/jupyter_client/manager.py#L239

