### PR TITLE
add note about installing and verifying the server extension

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ Node.js is required and can be installed with conda:
 conda install -c conda-forge nodejs
 ```
 
-The JupyterLab extension requires the server extension to be enabled. This can by done by running:
+The JupyterLab extension requires the server extension to be enabled. This can be done by running:
 
 ```bash
  jupyter serverextension enable voila --sys-prefix

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,18 @@ Node.js is required and can be installed with conda:
 conda install -c conda-forge nodejs
 ```
 
+The JupyterLab extension requires the server extension to be enabled. This can by done by running:
+
+```bash
+ jupyter serverextension enable voila --sys-prefix
+```
+
+You can verify if the server extension is enabled by running:
+
+```bash
+jupyter serverextension list
+```
+
 To install the JupyterLab extension locally:
 
 ```bash


### PR DESCRIPTION
As discussed with @jtpio, I added a note about making sure that the server extension is enabled when installing the JupyterLab extension, otherwise a 404 is produced.