### PR TITLE
Adds documentation about the template cookiecutter to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,4 +137,5 @@ python -m pytest
 
 The default templates are located in the following folder: [share/jupyter/voila/templates/default](./share/jupyter/voila/templates/default). They are automatically picked up when running voila in development mode.
 
-After editing the templates, reload the browser tab to see the changes.
+Alternatively, there is a Voila template cookiecutter available to give you a running start. [Link](https://github.com/aartgoossens/voila-template-cookiecutter).
+This cookiecutter contains some docker configuration for live reloading of your template changes to make development easier.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,5 +137,5 @@ python -m pytest
 
 The default templates are located in the following folder: [share/jupyter/voila/templates/default](./share/jupyter/voila/templates/default). They are automatically picked up when running voila in development mode.
 
-Alternatively, there is a Voila template cookiecutter available to give you a running start. [Link](https://github.com/aartgoossens/voila-template-cookiecutter).
+Alternatively, there is a Voila template cookiecutter available to give you a running start. [Link](https://github.com/voila-dashboards/voila-template-cookiecutter).
 This cookiecutter contains some docker configuration for live reloading of your template changes to make development easier.

--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -146,6 +146,13 @@ a Jupyter notebook by using the name of the folder in the ``--template`` paramet
 The result should be a Voila dashboard with your custom modifications made!
 
 
+Voila template cookiecutter
+-----------------------------
+There is a Voila template cookiecutter available to give you a running start.
+This cookiecutter contains some docker configuration for live reloading of your template changes to make development easier.
+Please refer to the `cookiecutter repo <https://github.com/voila-dashboards/voila-template-cookiecutter>`_ for more information on how to use the Voila template cookiecutter.
+
+
 Adding your own static files
 ============================
 


### PR DESCRIPTION
I talked about this PR with @jtpio during the PyConDE 2019 sprints.

I created a Voila template cookiecutter to:
1. Help the creation of new Voila templates.
2. Make template development easier by offering some docker configuration that let's you live reload your changes.

The cookiecutter can be found [here](https://github.com/AartGoossens/voila/pull/new/feature/template-cookiecutter-docs).
If you are willing to merge this PR I would also like to propose to copy the cookiecutter repo to the `voila-dashboards` Github organization.

Cheers!