### PR TITLE
chore: improve release instructions and include ipywidgets as test dep

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -23,7 +23,7 @@ Make sure the `dist/` folder is empty.
 2. `python setup.py sdist bdist_wheel`
 3. Double check the size of the bundles in the `dist/` folder
 4. Run the tests
-   * (pip install ".[test]" && cd tests/test_template && pip install . && cd .. && py.test)
+   * (pip install "dist/voila-X.Y.Z-py2.py3-none-any.whl[test]" && cd tests/test_template && pip install . && cd .. && py.test)
 5. `export TWINE_USERNAME=mypypi_username`
 6. `twine upload dist/*`
 

--- a/setup.py
+++ b/setup.py
@@ -387,6 +387,7 @@ setup_args = {
             'pytest<4',
             'pytest-tornado',
             'matplotlib'
+            'ipywidgets'
         ]
     },
     'author': 'QuantStack',


### PR DESCRIPTION
It is better to test the wheel since it will pick up packaging issues.