### PR TITLE
Allow comm open messages

### DIFF
--- a/voila/app.py
+++ b/voila/app.py
@@ -383,6 +383,7 @@ class Voila(Application):
             connection_dir=self.connection_dir,
             kernel_spec_manager=self.kernel_spec_manager,
             allowed_message_types=[
+                'comm_open',
                 'comm_msg',
                 'comm_info_request',
                 'kernel_info_request',

--- a/voila/app.py
+++ b/voila/app.py
@@ -384,6 +384,7 @@ class Voila(Application):
             kernel_spec_manager=self.kernel_spec_manager,
             allowed_message_types=[
                 'comm_open',
+                'comm_close',
                 'comm_msg',
                 'comm_info_request',
                 'kernel_info_request',


### PR DESCRIPTION
I have a mimerender extension that opens comms from the client side to communicate with the server (https://github.com/Quansight/ibis-vega-transform).

xref https://github.com/vidartf/phoila/pull/11 https://github.com/vidartf/phoila/issues/7 https://github.com/Quansight/ibis-vega-transform/pull/15