### PR TITLE
Setup GitHub Action for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,63 @@
+name: Tests
+
+on: [push]
+
+jobs:
+  run:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: [2.7, 3.6, 3.7]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Add conda to $PATH
+      run: echo ::add-path::$CONDA/condabin
+
+    - name: Update conda on Mac
+      if: matrix.os == 'macos-latest'
+      run: |
+        # sudo required?
+        sudo conda update -y -n base conda setuptools
+        
+    - name: Update conda on Linux
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        conda update -y -n base conda setuptools
+    
+    - name: Init conda
+      run: |
+        conda init bash
+        conda info -a
+
+    - name: Create the conda environment
+      run: conda create -q -y -n voila-tests -c conda-forge python=$PYTHON_VERSION pip jupyter_server==0.1.0 jupyterlab_pygments==0.1.0 pytest==3.10.1 nbconvert=5.6 pytest-cov nodejs flake8 ipywidgets matplotlib xeus-cling
+      env:
+        PYTHON_VERSION: ${{ matrix.python-version }}
+
+    - name: Install dependencies 
+      run: |
+        source "$CONDA/etc/profile.d/conda.sh"
+        conda activate voila-tests
+        whereis python
+        python --version
+        
+        python -m pip install ".[test]"
+        cd tests/test_template; pip install .; cd ../../;
+
+    - name: Flake8
+      run: |
+        source "$CONDA/etc/profile.d/conda.sh"
+        conda activate voila-tests
+        python -m flake8 voila tests setup.py
+
+    - name: Run tests
+      run: |
+        source "$CONDA/etc/profile.d/conda.sh"
+        conda activate voila-tests
+        VOILA_TEST_DEBUG=1 VOILA_TEST_XEUS_CLING=1 py.test tests/ --async-test-timeout=240
+        voila --help  # Making sure we can run `voila --help`


### PR DESCRIPTION
Setup GitHub Action for testing.

This is to evaluate GitHub Action as a replacement for Travis CI, and eventually add Windows testing to Voila (xref #432).

I quickly tried `windows-latest` as well, but ran into issues with conda. And also the tests using xeus-cling will have to be disabled for Windows.

@maartenbreddels there is an official `actions/setup-python@v1` for Python, but for `conda` we still have to do things manually it seems (setting up the path and activating the environment). 