### PR TITLE
Fix filtering of empty code cells.

### DIFF
--- a/voila/handler.py
+++ b/voila/handler.py
@@ -22,15 +22,6 @@ from .execute import executenb, VoilaExecutePreprocessor
 from .exporter import VoilaExporter
 
 
-# Filter for empty cells.
-def filter_empty_code_cells(cell, exporter):
-    return (
-        cell.cell_type != 'code' or                     # keep non-code cells
-        (cell.outputs and not exporter.exclude_output)  # keep cell if output not excluded and not empty
-        or not exporter.exclude_input                   # keep cell if input not excluded
-    )
-
-
 class VoilaHandler(JupyterHandler):
 
     def initialize(self, **kwargs):
@@ -129,7 +120,6 @@ class VoilaHandler(JupyterHandler):
     def _jinja_notebook_execute(self, nb, kernel_id):
         km = self.kernel_manager.get_kernel(kernel_id)
         result = executenb(nb, km=km, cwd=self.cwd, config=self.traitlet_config)
-        result.cells = list(filter(lambda cell: filter_empty_code_cells(cell, self.exporter), result.cells))
         # we modify the notebook in place, since the nb variable cannot be reassigned it seems in jinja2
         # e.g. if we do {% with nb = notebook_execute(nb, kernel_id) %}, the base template/blocks will not
         # see the updated variable (it seems to be local to our block)


### PR DESCRIPTION
When running `$ voila index.ipynb --template=reveal`, the right arrow (to navigate to the next slide) would become unavailable at the first code cell. The issue did not arise when using `voila index.ipynb --template=reveal --strip_sources=False` so we suspected an issue with filtering 'empty' code cells.

We recovered the expected behaviour by removing the `filter_empty_code_cells()` call in `handler.py`. It seems safe to remove this function entirely, because filtering has been handled in the front-end with CSS since the implementation of progressive rendering.