### PR TITLE
New docs section about example notebooks

### DIFF
--- a/docs/source/contribute.rst
+++ b/docs/source/contribute.rst
@@ -71,6 +71,10 @@ When making changes to the frontend side of Voilà, open a new terminal window a
 
 Then reload the browser tab.
 
+**Note**: the notebooks directory contains some examples that can be run with Voilà.
+Checkout the `instructions <using.html#the-example-notebooks>`__ in the user guide
+for details on how to run them.
+
 Extensions
 ==========
 
@@ -131,22 +135,6 @@ To install the JupyterLab extension locally:
    
    # start in watch mode to pick up changes automatically
    jupyter lab --watch
-
-Running the examples
-====================
-
-A few additional libraries can be installed to run the example notebooks:
-
-.. code-block:: bash
-
-   conda install -c conda-forge ipywidgets ipyvolume bqplot scipy
-
-The examples can then be served with:
-
-.. code-block:: bash
-
-   cd notebooks/
-   voila
 
 Tests
 =====

--- a/docs/source/using.rst
+++ b/docs/source/using.rst
@@ -89,3 +89,24 @@ When Voilà is run on a notebook, the following steps occur:
    Jupyter server.
 #. When users access the page, the widgets on the page have access to
    the underlying Jupyter kernel.
+
+The example notebooks
+=====================
+
+The `notebooks directory <https://github.com/voila-dashboards/voila/tree/master/notebooks>`__
+contains a collection of Jupyter notebooks that can be rendered using Voilà:
+
+* **basics.ipynb** - a notebook with interactions requiring a roundtrip to the kernel.
+* **bqplot.ipynb** - uses custom Jupyter widgets such as
+  `bqplot <https://github.com/bloomberg/bqplot>`__.
+* **dashboard.ipynb** - uses gridstack.js for the layout of each output.
+* **interactive.ipynb** - makes use of ipywidget's @interact.
+* **ipympl.ipynb** - contains custom interactive matplotlib figures using the
+  `ipympl <https://github.com/matplotlib/jupyter-matplotlib>`__ widget.
+* **ipyvolume.ipynb** - uses custom Jupyter widgets such as
+  `ipyvolume <https://github.com/maartenbreddels/ipyvolume>`__.
+* **xleaflet.ipynb** - a notebook that uses C++ kernel and interactive widgets
+
+These examples demonstrate different interactive HTML widgets and can be used as inspiration
+for getting started with Voilà. Checkout the `instructions <contribute.html#running-the-examples>`_
+in the contributor guide for how to run them.

--- a/docs/source/using.rst
+++ b/docs/source/using.rst
@@ -100,6 +100,9 @@ contains a collection of Jupyter notebooks that can be rendered using Voilà:
 * **bqplot.ipynb** - uses custom Jupyter widgets such as
   `bqplot <https://github.com/bloomberg/bqplot>`__.
 * **dashboard.ipynb** - uses gridstack.js for the layout of each output.
+* **gridspecLayout.ipynb** - uses
+  `GridspecLayout <https://ipywidgets.readthedocs.io/en/latest/examples/Layout%20Templates.html#Grid-layout>`__
+  for the layout of different widges.
 * **interactive.ipynb** - makes use of ipywidget's @interact.
 * **ipympl.ipynb** - contains custom interactive matplotlib figures using the
   `ipympl <https://github.com/matplotlib/jupyter-matplotlib>`__ widget.
@@ -110,11 +113,17 @@ contains a collection of Jupyter notebooks that can be rendered using Voilà:
 These examples demonstrate different interactive HTML widgets and can be used as inspiration
 for getting started with Voilà.
 
-To **run the example notebooks**, a few additional libraries can be installed :
+To **run the example notebooks**, a few additional libraries can be installed using:
 
 .. code-block:: bash
 
    conda install -c conda-forge ipywidgets ipyvolume bqplot scipy
+
+Or alternatively:
+
+.. code-block:: bash
+
+   conda env create
 
 The examples can then be served with:
 

--- a/docs/source/using.rst
+++ b/docs/source/using.rst
@@ -108,5 +108,17 @@ contains a collection of Jupyter notebooks that can be rendered using Voilà:
 * **xleaflet.ipynb** - a notebook that uses C++ kernel and interactive widgets
 
 These examples demonstrate different interactive HTML widgets and can be used as inspiration
-for getting started with Voilà. Checkout the `instructions <contribute.html#running-the-examples>`_
-in the contributor guide for how to run them.
+for getting started with Voilà.
+
+To **run the example notebooks**, a few additional libraries can be installed :
+
+.. code-block:: bash
+
+   conda install -c conda-forge ipywidgets ipyvolume bqplot scipy
+
+The examples can then be served with:
+
+.. code-block:: bash
+
+   cd notebooks/
+   voila

--- a/docs/source/using.rst
+++ b/docs/source/using.rst
@@ -102,7 +102,7 @@ contains a collection of Jupyter notebooks that can be rendered using Voilà:
 * **dashboard.ipynb** - uses gridstack.js for the layout of each output.
 * **gridspecLayout.ipynb** - uses
   `GridspecLayout <https://ipywidgets.readthedocs.io/en/latest/examples/Layout%20Templates.html#Grid-layout>`__
-  for the layout of different widges.
+  for the layout of different widgets.
 * **interactive.ipynb** - makes use of ipywidget's @interact.
 * **ipympl.ipynb** - contains custom interactive matplotlib figures using the
   `ipympl <https://github.com/matplotlib/jupyter-matplotlib>`__ widget.


### PR DESCRIPTION
Following the discussion in https://github.com/voila-dashboards/voila/pull/452, I added a section in the docs about the example notebooks.