### PR TITLE
Spinner update improvements

### DIFF
--- a/share/jupyter/voila/templates/default/nbconvert_templates/voila.tpl
+++ b/share/jupyter/voila/templates/default/nbconvert_templates/voila.tpl
@@ -46,15 +46,15 @@ a.anchor-link {
 {{ spinner.html() }}
 
 <script>
-  var voilaCellExecuteAfter = function(cell_index, cell_count) {};
+  var voilaCellExecuteAfter = function(cellIndex, cellCount) {};
 
-  var voilaCellExecuteBefore = function(cell_index, cell_count) {
+  var voilaCellExecuteBefore = function(cellIndex, cellCount) {
     var el = document.getElementById("loading_text");
-    el.innerHTML = `Executing ${cell_index} of ${cell_count}`;
+    el.innerHTML = `Executing ${cellIndex} of ${cellCount}`;
   };
 
   // Backward compatibility
-  var voila_process = function(cell_index, cell_count) {};
+  var voila_process = function(cellIndex, cellCount) {};
 </script>
 
 <div id="rendered_cells" style="display: none">
@@ -69,25 +69,25 @@ a.anchor-link {
         "kernelId": "{{kernel_id}}"
     }
     </script>
-    {% set cell_count = nb.cells|length %}
+    {% set cellCount = nb.cells|length %}
     {#
     Voila is using Jinja's Template.generate method to not render the whole template in one go.
     The current implementation of Jinja will however not yield template snippets if we call a blocks' super()
     Therefore it is important to have the cell loop in the template.
     The issue for Jinja is: https://github.com/pallets/jinja/issues/1044
     #}
-    <script>voilaCellExecuteBefore(1, {{ cell_count }});</script>
+    <script>voilaCellExecuteBefore(1, {{ cellCount }});</script>
     {%- for cell in cell_generator(nb, kernel_id) -%}
-      {% set cellloop = loop %}
+      {% set cellLoop = loop %}
       {%- block any_cell scoped -%}
-        <script>voila_process({{ cellloop.index }}, {{ cell_count }});</script>
-        {{ super() }}
+        <script>voila_process({{ cellLoop.index }}, {{ cellCount }});</script>
+          {{ super() }}
         <script>
-          voilaCellExecuteAfter({{ cellloop.index }}, {{ cell_count }});
+          voilaCellExecuteAfter({{ cellLoop.index }}, {{ cellCount }});
 
-          if ({{ cellloop.index }} != {{ cell_count }}) {
-            voilaCellExecuteBefore({{ cellloop.index }} + 1, {{ cell_count }});
-          }
+          {% if cellLoop.index != cellCount %}
+            voilaCellExecuteBefore({{ cellLoop.index }} + 1, {{ cellCount }});
+          {% endif %}
         </script>
       {%- endblock any_cell -%}
     {%- endfor -%}

--- a/share/jupyter/voila/templates/default/nbconvert_templates/voila.tpl
+++ b/share/jupyter/voila/templates/default/nbconvert_templates/voila.tpl
@@ -46,41 +46,52 @@ a.anchor-link {
 {{ spinner.html() }}
 
 <script>
-var voila_process = function(cell_index, cell_count) {
-  var el = document.getElementById("loading_text")
-  el.innerHTML = `Executing ${cell_index} of ${cell_count}`
-}
+  var voilaCellExecuteAfter = function(cell_index, cell_count) {};
+
+  var voilaCellExecuteBefore = function(cell_index, cell_count) {
+    var el = document.getElementById("loading_text");
+    el.innerHTML = `Executing ${cell_index} of ${cell_count}`;
+  };
+
+  // Backward compatibility
+  var voila_process = function(cell_index, cell_count) {};
 </script>
 
 <div id="rendered_cells" style="display: none">
 {%- endblock body_header -%}
 
 {%- block body_loop -%}
-{# from this point on, the kernel is started #}
-{%- with kernel_id = kernel_start() -%}
-  <script id="jupyter-config-data" type="application/json">
-  {
-      "baseUrl": "{{resources.base_url}}",
-      "kernelId": "{{kernel_id}}"
-  }
-  </script>
-  {% set cell_count = nb.cells|length %}
-  {#
-  Voila is using Jinja's Template.generate method to not render the whole template in one go.
-  The current implementation of Jinja will however not yield template snippets if we call a blocks' super()
-  Therefore it is important to have the cell loop in the template.
-  The issue for Jinja is: https://github.com/pallets/jinja/issues/1044
-  #}
-  {%- for cell in cell_generator(nb, kernel_id) -%}
-    {% set cellloop = loop %}
-    {%- block any_cell scoped -%}
-    <script>
-      voila_process({{ cellloop.index }}, {{ cell_count }})
+  {# from this point on, the kernel is started #}
+  {%- with kernel_id = kernel_start() -%}
+    <script id="jupyter-config-data" type="application/json">
+    {
+        "baseUrl": "{{resources.base_url}}",
+        "kernelId": "{{kernel_id}}"
+    }
     </script>
-      {{ super() }}
-    {%- endblock any_cell -%}
-  {%- endfor -%}
-{% endwith %}
+    {% set cell_count = nb.cells|length %}
+    {#
+    Voila is using Jinja's Template.generate method to not render the whole template in one go.
+    The current implementation of Jinja will however not yield template snippets if we call a blocks' super()
+    Therefore it is important to have the cell loop in the template.
+    The issue for Jinja is: https://github.com/pallets/jinja/issues/1044
+    #}
+    <script>voilaCellExecuteBefore(1, {{ cell_count }});</script>
+    {%- for cell in cell_generator(nb, kernel_id) -%}
+      {% set cellloop = loop %}
+      {%- block any_cell scoped -%}
+        <script>voila_process({{ cellloop.index }}, {{ cell_count }});</script>
+        {{ super() }}
+        <script>
+          voilaCellExecuteAfter({{ cellloop.index }}, {{ cell_count }});
+
+          if ({{ cellloop.index }} != {{ cell_count }}) {
+            voilaCellExecuteBefore({{ cellloop.index }} + 1, {{ cell_count }});
+          }
+        </script>
+      {%- endblock any_cell -%}
+    {%- endfor -%}
+  {% endwith %}
 {%- endblock body_loop -%}
 
 {%- block body_footer -%}


### PR DESCRIPTION
- rename `voila_process` function into `updateSpinner`
- replace `Executing 1 of 6` text by `Executed 1 of 6`. Because it's actually the number of executed cell that is displayed.
- indentation improvements