### PR TITLE
Bundle mathjax with Voilà

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -3842,8 +3842,7 @@
     "commander": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-      "dev": true
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -4410,6 +4409,11 @@
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"
       }
+    },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
     },
     "esrecurse": {
       "version": "4.2.1",
@@ -6230,6 +6234,16 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.2.tgz",
       "integrity": "sha512-LqxwVH3P/rqKX4EKGz7+c2G9r98WeM/SW34ybhgNGhUQNKtf1GmmSkJ6cDGJ/t6tiyae49qRkpyTw2B9HOrgUA=="
     },
+    "mathjax-full": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.0.0.tgz",
+      "integrity": "sha512-DvTUi2WvrACXZRjjzS0EbXY2ssRD23yuSMHVYZNbRuCA5zFZvu0MZWFy8QRvNYwJ44hJirJCNOCii0W0Q1R62A==",
+      "requires": {
+        "esm": "^3.2.25",
+        "mj-context-menu": "^0.2.0",
+        "speech-rule-engine": "^3.0.0-beta.6"
+      }
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -6401,6 +6415,11 @@
           }
         }
       }
+    },
+    "mj-context-menu": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.2.0.tgz",
+      "integrity": "sha512-yJxrWBHCjFZEHsZgfs7m5g9OSCNzsVYadW6f6lX3pgZL67vmodtSW/4zhsYmuDKweXfHs0M1kJge1uQIasWA+g=="
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -7816,6 +7835,16 @@
       "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
       "dev": true
     },
+    "speech-rule-engine": {
+      "version": "3.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-3.0.0-beta.6.tgz",
+      "integrity": "sha512-B7gcT53jAsKpx7WvFYQcyUlFmgS3Wa9KlDy0FY8SOTa+Wz5EqmI0MpCD5/fYm8/2qiCPp8HwZg+H3cBgM+sNVw==",
+      "requires": {
+        "commander": "*",
+        "wicked-good-xpath": "*",
+        "xmldom-sre": "^0.1.31"
+      }
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -8601,6 +8630,11 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
+    "wicked-good-xpath": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
+      "integrity": "sha1-gbDpXoZQ5JyUsiKY//hoa1VTz2w="
+    },
     "worker-farm": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
@@ -8655,6 +8689,11 @@
       "requires": {
         "async-limiter": "^1.0.0"
       }
+    },
+    "xmldom-sre": {
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/xmldom-sre/-/xmldom-sre-0.1.31.tgz",
+      "integrity": "sha512-f9s+fUkX04BxQf+7mMWAp5zk61pciie+fFLC9hX9UVvCeJQfNHRHXpeo5MPcR0EUf57PYLdt+ZO4f3Ipk2oZUw=="
     },
     "xtend": {
       "version": "4.0.1",

--- a/js/package.json
+++ b/js/package.json
@@ -16,7 +16,8 @@
     "@phosphor/signaling": "^1.2.2",
     "@phosphor/widgets": "^1.5.0",
     "core-js": "^3.1.0",
-    "font-awesome": "^4.7.0"
+    "font-awesome": "^4.7.0",
+    "mathjax-full": "^3.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",
@@ -31,6 +32,7 @@
     "webpack": "^4.29.3",
     "webpack-cli": "^3.2.3"
   },
+  "style": "style/index.css",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "prepare": "npm run build:lib && webpack",

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -7,7 +7,11 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
+import { PageConfig, URLExt } from '@jupyterlab/coreutils';
+import '../style/index.css';
+
 export { RenderMimeRegistry, standardRendererFactories } from '@jupyterlab/rendermime';
 
 export { WidgetManager } from './manager';
-export { connectKernel } from './kernel'
+export { connectKernel } from './kernel';
+export { renderMathJax } from './mathjax';

--- a/js/src/mathjax.js
+++ b/js/src/mathjax.js
@@ -1,0 +1,50 @@
+// MathJax core
+import { mathjax } from 'mathjax-full/js/mathjax';
+
+// TeX input
+import { TeX } from 'mathjax-full/js/input/tex';
+
+// HTML output
+import { CHTML } from 'mathjax-full/js/output/chtml';
+
+import { browserAdaptor } from 'mathjax-full/js/adaptors/browserAdaptor';
+
+import { TeXFont } from 'mathjax-full/js/output/chtml/fonts/tex';
+
+import { RegisterHTMLHandler } from 'mathjax-full/js/handlers/html';
+
+import { AllPackages } from 'mathjax-full/js/input/tex/AllPackages';
+
+// Register the HTML document handler
+RegisterHTMLHandler(browserAdaptor());
+
+// Override dynamically generated fonts in favor
+// of our font css that is picked up by webpack.
+class emptyFont extends TeXFont {}
+emptyFont.defaultFonts = {};
+
+const chtml = new CHTML({
+  font: new emptyFont()
+});
+
+const tex = new TeX({
+  packages: AllPackages,
+  inlineMath: [['$', '$'], ['\\(', '\\)']],
+  displayMath: [['$$', '$$'], ['\\[', '\\]']],
+  processEscapes: true,
+  processEnvironments: true
+});
+
+// initialize mathjax with with the browser DOM document; other documents are possible
+const html = mathjax.document(document, {
+  InputJax: tex,
+  OutputJax: chtml
+});
+
+export function renderMathJax() {
+  html.findMath()
+    .compile()
+    .getMetrics()
+    .typeset()
+    .updateDocument();
+};

--- a/js/style/index.css
+++ b/js/style/index.css
@@ -1,0 +1,109 @@
+@font-face /* 0 */ {
+  font-family: MJXZERO;
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Zero.woff") format("woff");
+}
+
+@font-face /* 1 */ {
+  font-family: MJXTEX;
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Main-Regular.woff") format("woff");
+}
+
+@font-face /* 2 */ {
+  font-family: MJXTEX-B;
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Main-Bold.woff") format("woff");
+}
+
+@font-face /* 3 */ {
+  font-family: MJXTEX-MI;
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Main-Italic.woff") format("woff");
+}
+
+@font-face /* 4 */ {
+  font-family: MJXTEX-I;
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Math-Italic.woff") format("woff");
+}
+
+@font-face /* 5 */ {
+  font-family: MJXTEX-BI;
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Math-BoldItalic.woff") format("woff");
+}
+
+@font-face /* 6 */ {
+  font-family: MJXTEX-S1;
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Size1-Regular.woff") format("woff");
+}
+
+@font-face /* 7 */ {
+  font-family: MJXTEX-S2;
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Size2-Regular.woff") format("woff");
+}
+
+@font-face /* 8 */ {
+  font-family: MJXTEX-S3;
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Size3-Regular.woff") format("woff");
+}
+
+@font-face /* 9 */ {
+  font-family: MJXTEX-S4;
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Size4-Regular.woff") format("woff");
+}
+
+@font-face /* 10 */ {
+  font-family: MJXTEX-A;
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_AMS-Regular.woff") format("woff");
+}
+
+@font-face /* 11 */ {
+  font-family: MJXTEX-C;
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Calligraphic-Regular.woff") format("woff");
+}
+
+@font-face /* 12 */ {
+  font-family: MJXTEX-C-B;
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Calligraphic-Bold.woff") format("woff");
+}
+
+@font-face /* 13 */ {
+  font-family: MJXTEX-FR;
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Fraktur-Regular.woff") format("woff");
+}
+
+@font-face /* 14 */ {
+  font-family: MJXTEX-FR-B;
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Fraktur-Bold.woff") format("woff");
+}
+
+@font-face /* 15 */ {
+  font-family: MJXTEX-SS;
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_SansSerif-Regular.woff") format("woff");
+}
+
+@font-face /* 16 */ {
+  font-family: MJXTEX-SS-B;
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_SansSerif-Bold.woff") format("woff");
+}
+
+@font-face /* 17 */ {
+  font-family: MJXTEX-SS-I;
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_SansSerif-Italic.woff") format("woff");
+}
+
+@font-face /* 18 */ {
+  font-family: MJXTEX-SC;
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Script-Regular.woff") format("woff");
+}
+
+@font-face /* 19 */ {
+  font-family: MJXTEX-T;
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Typewriter-Regular.woff") format("woff");
+}
+
+@font-face /* 20 */ {
+  font-family: MJXTEX-V;
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Vector-Regular.woff") format("woff");
+}
+
+@font-face /* 21 */ {
+  font-family: MJXTEX-VB;
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Vector-Bold.woff") format("woff");
+}

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -7,11 +7,11 @@ var rules = [
         'css-loader'
     ]},
     // required to load font-awesome
-    { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=application/font-woff' },
-    { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=application/font-woff' },
-    { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=application/octet-stream' },
-    { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, use: 'file-loader' },
-    { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=image/svg+xml' }
+    { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=application/font-woff&name=/voila/static/[hash].[ext]' },
+    { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=application/font-woff&name=/voila/static/[hash].[ext]' },
+    { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=application/octet-stream&name=/voila/static/[hash].[ext]' },
+    { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, use: 'file-loader&name=/voila/static/[hash].[ext]' },
+    { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=image/svg+xml&name=/voila/static/[hash].[ext]' }
 ]
 
 var distRoot = path.resolve(__dirname, '..', 'share', 'jupyter', 'voila', 'templates', 'default', 'static')

--- a/share/jupyter/voila/templates/default/nbconvert_templates/base.tpl
+++ b/share/jupyter/voila/templates/default/nbconvert_templates/base.tpl
@@ -1,5 +1,4 @@
 {%- extends 'lab.tpl' -%}
-{% from 'mathjax.tpl' import mathjax %}
 
 {%- block header -%}
 <!DOCTYPE html>

--- a/share/jupyter/voila/templates/default/nbconvert_templates/voila.tpl
+++ b/share/jupyter/voila/templates/default/nbconvert_templates/voila.tpl
@@ -1,5 +1,4 @@
 {%- extends 'base.tpl' -%}
-{% from 'mathjax.tpl' import mathjax %}
 {% import "spinner.tpl" as spinner %}
 
 {# this overrides the default behaviour of directly starting the kernel and executing the notebook #}
@@ -31,8 +30,6 @@ a.anchor-link {
   margin: 0.4em;
 }
 </style>
-
-{{ mathjax() }}
 
 {{ spinner.css() }}
 

--- a/share/jupyter/voila/templates/default/static/main.js
+++ b/share/jupyter/voila/templates/default/static/main.js
@@ -43,6 +43,8 @@ require(['static/voila'], function(voila) {
             window.addEventListener('beforeunload', function (e) {
                 kernel.shutdown()
             });
+
+            voila.renderMathJax();
         }
 
         if (document.readyState === 'complete') {


### PR DESCRIPTION
This appears to be working - but we still have an issue with the mathjax fonts because of the ` redirect_to_file`  function which redirects to the `files` directory (in command-line mode) or to the `render` directory (in the server extension mode).