### PR TITLE
Feature: start kernel async

### DIFF
--- a/share/jupyter/voila/templates/default/nbconvert_templates/base.tpl
+++ b/share/jupyter/voila/templates/default/nbconvert_templates/base.tpl
@@ -18,6 +18,18 @@
     crossorigin="anonymous">
 </script>
 
+<script>
+requirejs.config({ baseUrl: '{{resources.base_url}}voila/', waitSeconds: 30})
+requirejs(
+    [
+    {% for ext in resources.nbextensions -%}
+        "{{resources.base_url}}voila/nbextensions/{{ ext }}.js",
+    {% endfor %}
+    ]
+)
+</script>
+
+
 {% block notebook_execute %}
     {%- set kernel_id = kernel_start() -%}
     <script id="jupyter-config-data" type="application/json">
@@ -47,15 +59,7 @@
 {% block footer %}
 {% block footer_js %}
 <script>
-requirejs.config({ baseUrl: '{{resources.base_url}}voila/', waitSeconds: 30})
-requirejs(
-    [
-        "static/main",
-    {% for ext in resources.nbextensions -%}
-        "{{resources.base_url}}voila/nbextensions/{{ ext }}.js",
-    {% endfor %}
-    ]
-)
+requirejs(["static/main"])
 </script>
 
 {% endblock footer_js %}

--- a/voila/threading.py
+++ b/voila/threading.py
@@ -1,7 +1,6 @@
 import asyncio
-import concurrent.futures
-import inspect
 import threading
+import time
 import tornado.queues
 
 # As long as we support Python35, we use this library to get as async
@@ -51,3 +50,55 @@ def async_generator_to_thread(fn):
         gen = ThreadedAsyncGenerator(ioloop, fn, *args, **kwargs)
         return gen
     return wrapper
+
+
+def async_execute_in_current_thread(coroutine_function):
+    """Decorator which executes coroutine_function in the main thread, but invokable from any other thread as coroutine function"""
+    main_ioloop = asyncio.get_event_loop()
+    # Tornado queues can be created from a different thrad
+    request_queue = tornado.queues.Queue()  # will be used to put the unknown ioloop in (from the other thread)
+    result_queue = tornado.queues.Queue()  # will be used to put the result of the function call in
+
+    async def main_thread_task():
+        # we call the function directly
+        result = await coroutine_function()
+        # we then wait till some thread wants the result
+        thread_ioloop = await request_queue.get()
+
+        def thread_safe_put(result=result):
+            result_queue.put(result)
+        # and savely put it on the result_queue (which is why we need the thread's ioloop)
+        thread_ioloop.call_soon_threadsafe(thread_safe_put)
+    # we launch the task directly, which will wait for the thread
+    main_ioloop.create_task(main_thread_task())
+
+    async def wrapper_called_from_thread():
+        ioloop = asyncio.get_event_loop()
+
+        def thread_safe_put(thread_ioloop=ioloop):
+            request_queue.put(thread_ioloop)
+        main_ioloop.call_soon_threadsafe(thread_safe_put)
+        result = await result_queue.get()
+        return result
+    return wrapper_called_from_thread
+
+
+def busy_wait_execute_in_current_thread(coroutine_function):
+    """Decorator which executes coroutine_function in the main thread, but invokable from any other thread as a plain function"""
+    main_ioloop = asyncio.get_event_loop()
+    result = None
+
+    async def main_thread_task():
+        nonlocal result
+        # we call the function before we are asked
+        result = await coroutine_function()
+    # we launch the task directly
+    main_ioloop.create_task(main_thread_task())
+
+    def wrapper_called_from_thread():
+        # due to Python35 support we cannot ma
+        nonlocal result
+        while result is None:
+            time.sleep(0.05)
+        return result
+    return wrapper_called_from_thread


### PR DESCRIPTION
In #403 we had to start the kernel before we send the first bytes to the client, leading to a large time-to-first-byte TTFB (the HTML header containing script tags that the browser can already fetch). This is because we need to start the client in the main thread (something in 0mq is not thread safe I guess, causing the websocket connection to fail).

Here we start the kernel async from the main thread, and allow the jinja thread to access that.

It is a bit involved due to the py35 restriction.

I also moved the require/script tags up, so that the browser can fetch resources, even before the kernel is started.
