### PR TITLE
Pass Papermill parameters from request through to notebook

### DIFF
--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -328,3 +328,11 @@ To hide both the code cell and the output cell (if any) for every cell that has 
 
 You can use any tag you want but be sure to use the same tag name in the Voilà command.
 And please note that this functionality will only hide the cells in Voilà but will not prevent them from being executed.
+
+
+Integrate with Papermill for Parameterized Applications
+=======================================================
+
+If your notebook is setup to be parameterized with Papermill (e.g. first cell has "parameters" tag), you can inject parameters
+into your notebook by providing them as query parameters, or as JSON in the body of your request.
+

--- a/setup.py
+++ b/setup.py
@@ -242,7 +242,10 @@ setup_args = {
             'pytest-tornasync',
             'matplotlib',
             'ipywidgets'
-        ]
+        ],
+        'papermill': [
+            'papermill>=1.2.0,<3'
+        ],
     },
     'url': 'https://github.com/voila-dashboards/voila',
     'author': 'Voilà Development team',

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -13,8 +13,14 @@ class VoilaTest(voila.app.Voila):
 
 
 @pytest.fixture
+def voila_notebook(notebook_directory):
+    return os.path.join(notebook_directory, 'print_parameterized.ipynb')
+
+
+@pytest.fixture
 def voila_config():
     return lambda app: None
+
 
 
 @pytest.fixture

--- a/tests/app/execute_test.py
+++ b/tests/app/execute_test.py
@@ -5,6 +5,8 @@ import re
 import json
 import asyncio
 
+from urllib.parse import quote_plus
+
 try:
     from unittest import mock
 except ImportError:
@@ -17,6 +19,16 @@ async def test_hello_world(http_server_client, base_url):
     html_text = response.body.decode('utf-8')
     assert 'Hi Voilà' in html_text
     assert 'print(' not in html_text, 'by default the source code should be stripped'
+    assert 'test_template.css' not in html_text, "test_template should not be the default"
+
+
+async def test_parameters(http_client, base_url):
+    url = base_url + '?parameters=' + quote_plus('{"name":"Parameterized_Variable"}')
+    response = await http_client.fetch(url)
+    assert response.code == 200
+    html_text = response.body.decode('utf-8')
+    assert 'Hi Parameterized_Variable' in html_text
+    assert 'print' not in html_text, 'by default the source code should be stripped'
     assert 'test_template.css' not in html_text, "test_template should not be the default"
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,5 +18,10 @@ def print_notebook_url(base_url):
 
 
 @pytest.fixture
+ def print_parameterized_notebook_url(base_url):
+     return base_url + "voila/render/print_parameterized.ipynb"
+
+
+@pytest.fixture
 def voila_notebook(notebook_directory):
     return os.path.join(notebook_directory, 'print.ipynb')

--- a/tests/notebooks/print_parameterized.ipynb
+++ b/tests/notebooks/print_parameterized.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "name = 'Voila'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Hi ' + name + '!')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This PR does the following:
- tries to get the `parameters` argument from either the query parameter or body of the request
- if `parameters` is passed and it is a dict, it calls `papermill.parameterize.parameterize_notebook` on the underlying notebook, prior to execution