### PR TITLE
Fix ipywidgets.HTMLMath output

### DIFF
--- a/js/src/mathjax.js
+++ b/js/src/mathjax.js
@@ -46,5 +46,6 @@ export function renderMathJax() {
     .compile()
     .getMetrics()
     .typeset()
-    .updateDocument();
+    .updateDocument()
+    .reset();
 };

--- a/share/jupyter/voila/templates/default/static/main.js
+++ b/share/jupyter/voila/templates/default/static/main.js
@@ -37,13 +37,12 @@ require(['static/voila'], function(voila) {
 
         var widgetManager = new voila.WidgetManager(context, rendermime, settings);
 
-        function init() {
-            widgetManager.build_widgets();
+        async function init() {
             // it seems if we attach this to early, it will not be called
             window.addEventListener('beforeunload', function (e) {
                 kernel.shutdown()
             });
-
+            await widgetManager.build_widgets();
             voila.renderMathJax();
         }
 


### PR DESCRIPTION
Fix #488 

By executing `voila.renderMathJax()` after  `await widgetManager.build_widgets()` we are sure that mathjax is working on a page with already built widgets.

I also added  `.reset()` to `renderMathJax()` to [reset the internal flags](https://docs.mathjax.org/en/latest/options/document.html#document-renderactions)