### PR TITLE
Use Python 3.5 in GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [2.7, 3.6, 3.7]
+        python-version: [3.5, 3.6, 3.7]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
New changes on master since https://github.com/voila-dashboards/voila/pull/445 was open, for example https://github.com/voila-dashboards/voila/pull/403 which drops Python 2.7.

We can update the GitHub Actions workflow to reflect that change too, since it's failing on master: https://github.com/voila-dashboards/voila/runs/333012981