### PR TITLE
chore(ci): travis did not fail on flake due to using after_script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,14 @@
 name: Tests
 
-on: [push]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+  schedule:
+  - cron: "0 2 * * 1-5"  # run on weekdays at 2:00am UTC
 
 jobs:
   run:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
         conda info -a
 
     - name: Create the conda environment
-      run: conda create -q -y -n voila-tests -c conda-forge python=$PYTHON_VERSION pip jupyter_server==0.1.0 jupyterlab_pygments==0.1.0 pytest==3.10.1 nbconvert=5.6 pytest-cov nodejs flake8 ipywidgets matplotlib xeus-cling
+      run: conda create -q -y -n voila-tests -c conda-forge python=$PYTHON_VERSION pip jupyterlab_pygments==0.1.0 nbconvert=5.5 pytest-cov nodejs flake8 ipywidgets matplotlib xeus-cling
       env:
         PYTHON_VERSION: ${{ matrix.python-version }}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,7 @@ before_install:
 install:
   - pip install ".[test]"
   - cd tests/test_template; pip install .; cd ../../;
-after_script:
-  - flake8 voila tests setup.py
 script:
   - VOILA_TEST_DEBUG=1 VOILA_TEST_XEUS_CLING=1 py.test tests/ --async-test-timeout=240
   - voila --help  # Making sure we can run `voila --help`
+  - flake8 voila tests setup.py

--- a/voila/execute.py
+++ b/voila/execute.py
@@ -214,7 +214,7 @@ class VoilaExecutePreprocessor(ExecutePreprocessor):
             self.strip_code_cell_errors(cell)
 
         return nb
-    
+
     def strip_code_cell_errors(self, cell):
         """Strip any error outputs and traceback from a code cell."""
         # There is no 'outputs' key for markdown cells
@@ -233,6 +233,7 @@ class VoilaExecutePreprocessor(ExecutePreprocessor):
             output['traceback'] = [error_message]
 
         return cell
+
 
 def executenb(nb, cwd=None, km=None, **kwargs):
     resources = {}

--- a/voila/threading.py
+++ b/voila/threading.py
@@ -1,6 +1,4 @@
 import asyncio
-import concurrent.futures
-import inspect
 import threading
 import tornado.queues
 


### PR DESCRIPTION
As explained at https://docs.travis-ci.com/user/job-lifecycle/ after_script failures do not cause a build to fail, causing us to not obey flake. Also, actions do no run on PR's. Fixes coming.