### PR TITLE
fix: the default title in the template is always Notebook

### DIFF
--- a/tests/app/execute_test.py
+++ b/tests/app/execute_test.py
@@ -19,7 +19,7 @@ def test_hello_world(http_client, base_url):
     assert response.code == 200
     html_text = response.body.decode('utf-8')
     assert 'Hi Voila' in html_text
-    assert 'print' not in html_text, 'by default the source code should be stripped'
+    assert 'print(' not in html_text, 'by default the source code should be stripped'
     assert 'test_template.css' not in html_text, "test_template should not be the default"
 
 

--- a/tests/server/execute_test.py
+++ b/tests/server/execute_test.py
@@ -8,5 +8,5 @@ def test_hello_world(http_client, print_notebook_url):
     assert response.code == 200
     html_text = response.body.decode('utf-8')
     assert 'Hi Voila' in html_text
-    assert 'print' not in html_text, 'by default the source code should be stripped'
+    assert 'print(' not in html_text, 'by default the source code should be stripped'
     assert 'test_template.css' not in html_text, "test_template should not be the default"

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -59,11 +59,17 @@ class VoilaHandler(JupyterHandler):
             return
         self.cwd = os.path.dirname(notebook_path)
 
+        path, basename = os.path.split(notebook_path)
+        notebook_name = os.path.splitext(basename)[0]
+
         # render notebook to html
         resources = {
             'base_url': self.base_url,
             'nbextensions': nbextensions,
-            'theme': self.voila_configuration.theme
+            'theme': self.voila_configuration.theme,
+            'metadata': {
+                'name': notebook_name
+            }
         }
 
         # include potential extra resources


### PR DESCRIPTION
The property used as a fallback for the title of the template is
not initialized by Voila. Following nbconvert, in which this
property is set to the filename of the notebook [1], this commit
now does the same.

Related to: voila-dashboards/voila-vuetify#25

[1] https://github.com/jupyter/nbconvert/blob/6c6e5fa0c757169017fd325fad98efa8d4a368ea/nbconvert/exporters/exporter.py#L172