### PR TITLE
Add documentation for the enable_nbextensions flag

### DIFF
--- a/docs/source/using.rst
+++ b/docs/source/using.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2018, Voila Contributors
    Copyright (c) 2018, QuantStack
-   
+
    Distributed under the terms of the BSD 3-Clause License.
-   
+
    The full license is in the file LICENSE, distributed with this software.
 
 .. _using:
@@ -131,3 +131,25 @@ The examples can then be served with:
 
    cd notebooks/
    voila
+
+
+Using third-party Widgets with Voilà
+====================================
+
+By default, Voilà doesn't serve Jupyter Widgets installed as a classic notebook extension (nbextension).
+
+Instead, it fallbacks to fetching the files from a CDN. This might result in an error (404) in case the
+custom widget has not been published to ``npm``, or when Voilà runs in an environment without an Internet
+connection.
+
+To let the Voilà standalone app serve the nbextensions, use the ``enable_nbextensions`` flag as follows:
+
+.. code-block:: bash
+
+   voila --enable_nbextensions=True
+
+When using Voilà as a server extension:
+
+.. code-block:: bash
+
+    jupyter notebook --VoilaConfiguration.enable_nbextensions=True


### PR DESCRIPTION
Fixes #428.

Add a section about using the `enable_nbextensions` flag in the documentation..

This was brought up several times in https://github.com/voila-dashboards/voila/issues/482, https://github.com/voila-dashboards/voila/issues/325, https://github.com/voila-dashboards/voila/issues/412 and others.