### PR TITLE
Update the JupyterLab preview extension

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: Build JupyterLab extension
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+  schedule:
+  - cron: "0 2 * * 1-5"  # run on weekdays at 2:00am UTC
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Install node
+      uses: actions/setup-node@v1
+      with:
+       node-version: '12.x'
+    - name: Install Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.7'
+        architecture: 'x64'
+    - name: Install JupyterLab
+      run: python -m pip install jupyterlab
+    - name: Install the Voila Preview JupyterLab extension
+      run: |
+        cd packages/jupyterlab-voila
+        jlpm && jlpm run build
+        jupyter labextension install .
+    - name: Browser check
+      run: python -m jupyterlab.browser_check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,8 +106,11 @@ jupyter serverextension list
 To install the JupyterLab extension locally:
 
 ```bash
-jupyter labextension install @jupyter-widgets/jupyterlab-manager
-jupyter labextension install ./packages/jupyterlab-voila
+cd ./packages/jupyterlab-voila
+
+jlpm
+jlpm run build
+jupyter labextension install @jupyter-widgets/jupyterlab-manager . --debug
 
 # start in watch mode to pick up changes automatically
 jupyter lab --watch

--- a/packages/jupyterlab-voila/src/index.ts
+++ b/packages/jupyterlab-voila/src/index.ts
@@ -1,7 +1,19 @@
 import {
   JupyterFrontEnd,
-  JupyterFrontEndPlugin,
+  JupyterFrontEndPlugin
 } from "@jupyterlab/application";
+
+import {
+  ICommandPalette,
+  WidgetTracker,
+  ToolbarButton
+} from "@jupyterlab/apputils";
+
+import { PageConfig, PathExt, ISettingRegistry } from "@jupyterlab/coreutils";
+
+import { DocumentRegistry } from "@jupyterlab/docregistry";
+
+import { IMainMenu } from "@jupyterlab/mainmenu";
 
 import {
   INotebookTracker,
@@ -9,19 +21,9 @@ import {
   INotebookModel
 } from "@jupyterlab/notebook";
 
-import { ReadonlyJSONObject } from "@phosphor/coreutils";
-
-import { ICommandPalette, WidgetTracker } from "@jupyterlab/apputils";
-
-import { IMainMenu } from "@jupyterlab/mainmenu";
-
-import { PageConfig, PathExt, ISettingRegistry } from "@jupyterlab/coreutils";
-
-import { ToolbarButton } from "@jupyterlab/apputils";
-
-import { DocumentRegistry } from "@jupyterlab/docregistry";
-
 import { CommandRegistry } from "@phosphor/commands";
+
+import { ReadonlyJSONObject } from "@phosphor/coreutils";
 
 import { IDisposable } from "@phosphor/disposable";
 
@@ -33,29 +35,40 @@ import {
 
 import "../style/index.css";
 
+/**
+ * The command IDs used by the plugin.
+ */
 export namespace CommandIDs {
   export const voilaRender = "notebook:render-with-voila";
 
   export const voilaOpen = "notebook:open-with-voila";
 }
 
+/**
+ * A notebook widget extension that adds a voila preview button to the toolbar.
+ */
 class VoilaRenderButton
   implements DocumentRegistry.IWidgetExtension<NotebookPanel, INotebookModel> {
+  /**
+   * Instantiate a new VoilaRenderButton.
+   * @param commands The command registry.
+   */
   constructor(commands: CommandRegistry) {
     this._commands = commands;
   }
 
+  /**
+   * Create a new extension object.
+   */
   createNew(panel: NotebookPanel): IDisposable {
-    const renderVoila = () => {
-      this._commands.execute("notebook:render-with-voila");
-    };
     const button = new ToolbarButton({
       className: "voilaRender",
+      tooltip: "Render with Voila",
       iconClassName: VOILA_ICON_CLASS,
-      onClick: renderVoila,
-      tooltip: "Render with Voila"
+      onClick: () => {
+        this._commands.execute(CommandIDs.voilaRender);
+      }
     });
-
     panel.toolbar.insertAfter("cellType", "voilaRender", button);
     return button;
   }
@@ -124,7 +137,9 @@ const extension: JupyterFrontEndPlugin<IVoilaPreviewTracker> = {
         });
     }
 
-    app.commands.addCommand(CommandIDs.voilaRender, {
+    const { commands, docRegistry } = app;
+
+    commands.addCommand(CommandIDs.voilaRender, {
       label: "Render Notebook with Voila",
       execute: async args => {
         const current = getCurrent(args);
@@ -145,7 +160,7 @@ const extension: JupyterFrontEndPlugin<IVoilaPreviewTracker> = {
       isEnabled
     });
 
-    app.commands.addCommand(CommandIDs.voilaOpen, {
+    commands.addCommand(CommandIDs.voilaOpen, {
       label: "Open with Voila in New Browser Tab",
       execute: async args => {
         const current = getCurrent(args);
@@ -180,8 +195,8 @@ const extension: JupyterFrontEndPlugin<IVoilaPreviewTracker> = {
       );
     }
 
-    const voilaButton = new VoilaRenderButton(app.commands);
-    app.docRegistry.addWidgetExtension("Notebook", voilaButton);
+    const voilaButton = new VoilaRenderButton(commands);
+    docRegistry.addWidgetExtension("Notebook", voilaButton);
 
     return tracker;
   }

--- a/packages/jupyterlab-voila/src/preview.tsx
+++ b/packages/jupyterlab-voila/src/preview.tsx
@@ -1,4 +1,10 @@
-import { IFrame, ToolbarButton, ReactWidget, MainAreaWidget } from "@jupyterlab/apputils";
+import {
+  IFrame,
+  MainAreaWidget,
+  ToolbarButton,
+  ReactWidget,
+  IWidgetTracker
+} from "@jupyterlab/apputils";
 
 import {
   DocumentRegistry
@@ -6,9 +12,23 @@ import {
 
 import { INotebookModel } from "@jupyterlab/notebook";
 
+import { Token } from "@phosphor/coreutils";
+
 import { Signal } from '@phosphor/signaling';
 
 import * as React from "react";
+
+/**
+ * A class that tracks Voila Preview widgets.
+ */
+export interface IVoilaPreviewTracker extends IWidgetTracker<VoilaPreview> {}
+
+/**
+ * The Voila Preview tracker token.
+ */
+export const IVoilaPreviewTracker = new Token<IVoilaPreviewTracker>(
+  "@jupyter-voila/jupyterlab-preview:IVoilaPreviewTracker"
+);
 
 export const VOILA_ICON_CLASS = "jp-MaterialIcon jp-VoilaIcon";
 
@@ -40,9 +60,9 @@ export class VoilaPreview extends MainAreaWidget<IFrame> {
           style={{ verticalAlign: "middle" }}
           name="renderOnSave"
           type="checkbox"
-          defaultChecked={this.renderOnSave}
+          defaultChecked={renderOnSave}
           onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-            this.renderOnSave = event.target.checked;
+            this._renderOnSave = event.target.checked;
           }}
         />
         Render on Save
@@ -66,6 +86,7 @@ export class VoilaPreview extends MainAreaWidget<IFrame> {
       return;
     }
     Signal.clearData(this);
+    super.dispose();
   }
 
   reload() {
@@ -73,7 +94,7 @@ export class VoilaPreview extends MainAreaWidget<IFrame> {
     if (iframe.contentWindow) {
       iframe.contentWindow.location.reload();
     }
-  }
+  };
 
   get renderOnSave(): boolean {
     return this._renderOnSave;

--- a/packages/jupyterlab-voila/src/preview.tsx
+++ b/packages/jupyterlab-voila/src/preview.tsx
@@ -6,15 +6,13 @@ import {
   IWidgetTracker
 } from "@jupyterlab/apputils";
 
-import {
-  DocumentRegistry
-} from "@jupyterlab/docregistry";
+import { DocumentRegistry } from "@jupyterlab/docregistry";
 
 import { INotebookModel } from "@jupyterlab/notebook";
 
 import { Token } from "@phosphor/coreutils";
 
-import { Signal } from '@phosphor/signaling';
+import { Signal } from "@phosphor/signaling";
 
 import * as React from "react";
 
@@ -30,9 +28,19 @@ export const IVoilaPreviewTracker = new Token<IVoilaPreviewTracker>(
   "@jupyter-voila/jupyterlab-preview:IVoilaPreviewTracker"
 );
 
+/**
+ * The class name for a Voila preview icon.
+ */
 export const VOILA_ICON_CLASS = "jp-MaterialIcon jp-VoilaIcon";
 
+/**
+ * A MainAreaWidget that shows a Voila preview in an IFrame.
+ */
 export class VoilaPreview extends MainAreaWidget<IFrame> {
+  /**
+   * Instantiate a new VoilaPreview.
+   * @param options The VoilaPreview instantiation options.
+   */
   constructor(options: VoilaPreview.IOptions) {
     super({
       ...options,
@@ -51,7 +59,9 @@ export class VoilaPreview extends MainAreaWidget<IFrame> {
     const reloadButton = new ToolbarButton({
       iconClassName: "jp-RefreshIcon",
       tooltip: "Reload Preview",
-      onClick: () => { this.reload(); }
+      onClick: () => {
+        this.reload();
+      }
     });
 
     const renderOnSaveCheckbox = ReactWidget.create(
@@ -81,6 +91,9 @@ export class VoilaPreview extends MainAreaWidget<IFrame> {
     });
   }
 
+  /**
+   * Dispose the preview widget.
+   */
   dispose() {
     if (this.isDisposed) {
       return;
@@ -89,17 +102,26 @@ export class VoilaPreview extends MainAreaWidget<IFrame> {
     super.dispose();
   }
 
+  /**
+   * Reload the preview.
+   */
   reload() {
     const iframe = this.content.node.querySelector("iframe")!;
     if (iframe.contentWindow) {
       iframe.contentWindow.location.reload();
     }
-  };
+  }
 
+  /**
+   * Get whether the preview reloads when the context is saved.
+   */
   get renderOnSave(): boolean {
     return this._renderOnSave;
   }
 
+  /**
+   * Set whether the preview reloads when the context is saved.
+   */
   set renderOnSave(renderOnSave: boolean) {
     this._renderOnSave = renderOnSave;
   }
@@ -107,15 +129,42 @@ export class VoilaPreview extends MainAreaWidget<IFrame> {
   private _renderOnSave: boolean;
 }
 
+/**
+ * A namespace for VoilaPreview statics.
+ */
 export namespace VoilaPreview {
+  /**
+   * Instantiation options for `VoilaPreview`.
+   */
   export interface IOptions extends MainAreaWidget.IOptionsOptionalContent {
+    /**
+     * The Voila URL.
+     */
     url: string;
+
+    /**
+     * The preview label.
+     */
     label: string;
+
+    /**
+     * The notebook document context.
+     */
     context: DocumentRegistry.IContext<INotebookModel>;
+
+    /**
+     * Whether to reload the preview on context saved.
+     */
     renderOnSave: boolean;
   }
 }
 
+/**
+ * A namespace for module private data.
+ */
 namespace Private {
+  /**
+   * Counter used as a voila preview widget id.
+   */
   export let count = 0;
 }

--- a/packages/jupyterlab-voila/src/preview.tsx
+++ b/packages/jupyterlab-voila/src/preview.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 /**
  * A class that tracks Voila Preview widgets.
  */
-export interface IVoilaPreviewTracker extends IWidgetTracker<VoilaPreview> {}
+export interface IVoilaPreviewTracker extends IWidgetTracker<VoilaPreview> { }
 
 /**
  * The Voila Preview tracker token.
@@ -52,7 +52,6 @@ export class VoilaPreview extends MainAreaWidget<IFrame> {
     this.content.url = url;
     this.content.title.label = label;
     this.content.title.icon = VOILA_ICON_CLASS;
-    this.content.id = `voila-preview-${++Private.count}`;
 
     this.renderOnSave = renderOnSave;
 
@@ -80,15 +79,17 @@ export class VoilaPreview extends MainAreaWidget<IFrame> {
     );
 
     this.toolbar.addItem("reload", reloadButton);
-    this.toolbar.addItem("renderOnSave", renderOnSaveCheckbox);
 
-    void context.ready.then(() => {
-      context.fileChanged.connect(() => {
-        if (this.renderOnSave) {
-          this.reload();
-        }
+    if (context) {
+      this.toolbar.addItem("renderOnSave", renderOnSaveCheckbox);
+      void context.ready.then(() => {
+        context.fileChanged.connect(() => {
+          if (this.renderOnSave) {
+            this.reload();
+          }
+        });
       });
-    });
+    }
   }
 
   /**
@@ -98,8 +99,8 @@ export class VoilaPreview extends MainAreaWidget<IFrame> {
     if (this.isDisposed) {
       return;
     }
-    Signal.clearData(this);
     super.dispose();
+    Signal.clearData(this);
   }
 
   /**
@@ -148,23 +149,13 @@ export namespace VoilaPreview {
     label: string;
 
     /**
-     * The notebook document context.
+     * An optional notebook document context.
      */
-    context: DocumentRegistry.IContext<INotebookModel>;
+    context?: DocumentRegistry.IContext<INotebookModel>;
 
     /**
      * Whether to reload the preview on context saved.
      */
-    renderOnSave: boolean;
+    renderOnSave?: boolean;
   }
-}
-
-/**
- * A namespace for module private data.
- */
-namespace Private {
-  /**
-   * Counter used as a voila preview widget id.
-   */
-  export let count = 0;
 }


### PR DESCRIPTION
A quick pass on the JupyterLab preview extension to clean up the code and prepare for the move to JupyterLab 2.0 (to be done in a separate PR later).

### Changes

- Code cleanup
- Add a `WidgetTracker` for Voila Preview, so other extensions could potentially consume it and for example add custom components to the toolbar
- Follow JupyterLab code style (add docstrings, naming convention) so it's easier to navigate the code
- Restore the Voila Preview widgets. For now the restored preview loses track of the notebook context and has the "Render on Save" button removed. We could switch to making the preview a Document Widget extension in the future. In that case the preview would become another "view" on a notebook (see #490)
- Add GitHub Actions workflow to build the extension

![restore-preview](https://user-images.githubusercontent.com/591645/73008782-95fc6880-3e0f-11ea-8b82-93f0c51d721a.gif)