### PR TITLE
Dispose kernel on beforeunload event

### DIFF
--- a/share/jupyter/voila/templates/default/static/main.js
+++ b/share/jupyter/voila/templates/default/static/main.js
@@ -12,7 +12,7 @@ require(['static/voila'], function(voila) {
     (async function() {
         var kernel = await voila.connectKernel()
 
-        const context = { 
+        const context = {
             session: {
                 kernel,
                 kernelChanged: {
@@ -41,7 +41,8 @@ require(['static/voila'], function(voila) {
             widgetManager.build_widgets();
             // it seems if we attach this to early, it will not be called
             window.addEventListener('beforeunload', function (e) {
-                kernel.shutdown()
+                kernel.shutdown();
+                kernel.dispose();
             });
 
             voila.renderMathJax();


### PR DESCRIPTION
This should fix #237 and fix #173.

The current `kernel.shutdown()` logic is implemented in: https://github.com/jupyterlab/jupyterlab/blob/f5e5b0e50873042c101e913c1403aab5c8b9447c/packages/services/src/kernel/default.ts#L456-L465.

The call is async and waits for the response from the server before clearing the socket.

We don't need to wait for the response and instead can dispose the kernel directly, which clears the socket.