### PR TITLE
Fix: Respect allow_errors value

### DIFF
--- a/tests/app/notebooks_test.py
+++ b/tests/app/notebooks_test.py
@@ -1,4 +1,6 @@
 # simply tests if some notebooks execute
+import sys
+
 import pytest
 
 
@@ -8,6 +10,7 @@ def voila_args(notebook_directory, voila_args_extra):
 
 
 @pytest.mark.gen_test
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="Matplotlib installation issue on MacOS, Python 3.5")
 def test_other_comms(http_client, base_url):
     response = yield http_client.fetch(base_url + '/voila/render/other_comms.ipynb')
     html_text = response.body.decode('utf-8')


### PR DESCRIPTION
This will fix #519.

It will respect the value of the `allow_errors` option.

If `allow_errors` is `False` (default), the execution will stop on the first error, and the traceback of the last error will be visible only if Voila is run with `--debug`.

If `allow_errors` is `True`, the execution does not stop on errors, and tracebacks are visible only if Voila is run with `--debug`.