### PR TITLE
fix: mock v2 api of MathJax

### DIFF
--- a/js/src/mathjax.js
+++ b/js/src/mathjax.js
@@ -48,4 +48,16 @@ export function renderMathJax() {
     .typeset()
     .updateDocument()
     .reset();
+  window.MathJax = {
+    Hub: {
+      Queue: ([_ignore, _ignore2, node]) => {
+        html.findMath({ elements: [node] })
+            .compile()
+            .getMetrics()
+            .typeset()
+            .updateDocument()
+            .reset()
+      }
+    }
+  }
 };


### PR DESCRIPTION

This is a workaround or fix for #516

There are a few problems:
 * We wait for the widgets to be build before we render mathjax, however, if widgets are inside a VBox, they may be rendered async, so they come after mathjax is done.
 * typeset in https://github.com/jupyter-widgets/ipywidgets/blob/b3708e1305248b132999322266aab07c7e9ec3dc/packages/controls/src/utils.ts#L16 (which is called by description widget in https://github.com/jupyter-widgets/ipywidgets/blob/b3708e1305248b132999322266aab07c7e9ec3dc/packages/controls/src/widget_description.ts#L62) uses the v2 API of MathJax, while we use v3 since #470 (since voila 0.1.18)

In this PR I mock the v2 API a bit, and rerender all math. I am not sure we should do this.

cc @jasongrout 
We could go mathjax v3 on all platforms, notebook, lab, widgets, or revert to v2 mathjax in voila.