### PR TITLE
Show timeout error in cell output

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,14 +26,12 @@ jobs:
     - name: Add conda to $PATH
       run: echo ::add-path::$CONDA/condabin
 
-    - name: Update conda on Mac
+    - name: Fix permissions on Mac
       if: matrix.os == 'macos-latest'
       run: |
-        # sudo required?
-        sudo conda update -y -n base conda setuptools
-        
-    - name: Update conda on Linux
-      if: matrix.os == 'ubuntu-latest'
+        sudo chmod -R a+rw /usr/local/miniconda
+
+    - name: Update conda
       run: |
         conda update -y -n base conda setuptools
     

--- a/tests/app/timeout_test.py
+++ b/tests/app/timeout_test.py
@@ -1,0 +1,20 @@
+import pytest
+
+import os
+
+
+@pytest.fixture
+def voila_notebook(notebook_directory):
+    return os.path.join(notebook_directory, 'sleep.ipynb')
+
+
+@pytest.fixture
+def voila_args_extra():
+    return ['--VoilaExecutePreprocessor.timeout=1']
+
+
+@pytest.mark.gen_test
+def test_timeout(http_client, base_url):
+    response = yield http_client.fetch(base_url)
+    html_text = response.body.decode('utf-8')
+    assert 'Cell execution timed out' in html_text

--- a/tests/app/timeout_test.py
+++ b/tests/app/timeout_test.py
@@ -10,7 +10,7 @@ def voila_notebook(notebook_directory):
 
 @pytest.fixture
 def voila_args_extra():
-    return ['--VoilaExecutePreprocessor.timeout=1']
+    return ['--VoilaExecutePreprocessor.timeout=1', '--KernelManager.shutdown_wait_time=0.1']
 
 
 @pytest.mark.gen_test

--- a/tests/notebooks/sleep.ipynb
+++ b/tests/notebooks/sleep.ipynb
@@ -1,0 +1,35 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "time.sleep(10)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/voila/execute.py
+++ b/voila/execute.py
@@ -8,10 +8,7 @@
 #############################################################################
 import collections
 import logging
-try:
-    from time import monotonic  # Py 3
-except ImportError:
-    from time import time as monotonic  # Py 2
+from time import monotonic
 
 from nbconvert.preprocessors import ClearOutputPreprocessor
 from nbconvert.preprocessors.execute import CellExecutionError, ExecutePreprocessor
@@ -20,11 +17,6 @@ import zmq
 
 from traitlets import Unicode
 from ipykernel.jsonutil import json_clean
-
-try:
-    TimeoutError  # Py 3
-except NameError:
-    TimeoutError = RuntimeError  # Py 2
 
 
 def strip_code_cell_warnings(cell):

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -21,11 +21,6 @@ from nbconvert.preprocessors import ClearOutputPreprocessor
 from .execute import executenb, VoilaExecutePreprocessor
 from .exporter import VoilaExporter
 
-try:
-    TimeoutError  # Py 3
-except NameError:
-    TimeoutError = RuntimeError  # Py 2
-
 
 class VoilaHandler(JupyterHandler):
 

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -21,6 +21,11 @@ from nbconvert.preprocessors import ClearOutputPreprocessor
 from .execute import executenb, VoilaExecutePreprocessor
 from .exporter import VoilaExporter
 
+try:
+    TimeoutError  # Py 3
+except NameError:
+    TimeoutError = RuntimeError  # Py 2
+
 
 class VoilaHandler(JupyterHandler):
 
@@ -140,9 +145,16 @@ class VoilaHandler(JupyterHandler):
         nb, resources = ClearOutputPreprocessor().preprocess(nb, {'metadata': {'path': self.cwd}})
         ep = VoilaExecutePreprocessor(config=self.traitlet_config)
 
+        stop_execution = False
         with ep.setup_preprocessor(nb, resources, km=km):
             for cell_idx, cell in enumerate(nb.cells):
-                res = ep.preprocess_cell(cell, resources, cell_idx, store_history=False)
+                if stop_execution:
+                    break
+                try:
+                    res = ep.preprocess_cell(cell, resources, cell_idx, store_history=False)
+                except TimeoutError:
+                    res = (cell, resources)
+                    stop_execution = True
 
                 yield res[0]
 


### PR DESCRIPTION
When a cell execution times out, the page hangs with the spinner. There is a timeout exception in the terminal but the user has no clue as to what it happening.
The notebook execution should be aborted and a timeout error should be printed in the cell output.
Fixes #538 