### PR TITLE
chore: allow nbconvert v6.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -377,7 +377,7 @@ setup_args = {
     'install_requires': [
         'async_generator',
         'jupyter_server>=0.1.0,<0.2.0',
-        'nbconvert>=5.5.0,<6',
+        'nbconvert>=5.5.0,<7',
         'jupyterlab_pygments>=0.1.0,<0.2',
         'pygments>=2.4.1,<3'  # Explicitly requiring pygments which is a second-order dependency.
                               # An older versions is generally installed already and is otherwise not updated by pip.


### PR DESCRIPTION
With https://github.com/jupyter/nbconvert/pull/1173 we could allow nbconvert 6 already, at least it works with that branch. 