### PR TITLE
Pin to JupyterLab 1 on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         python-version: '3.7'
         architecture: 'x64'
     - name: Install JupyterLab
-      run: python -m pip install jupyterlab
+      run: python -m pip install jupyterlab==1.2.7
     - name: Install the Voila Preview JupyterLab extension
       run: |
         cd packages/jupyterlab-voila


### PR DESCRIPTION
Until #553 is fixed, let's pin CI to use JupyterLab 1.2.7.