### PR TITLE
Update links to jupyter-xeus and voila-dashboards orgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The sources of the Jupyter notebook can be displayed in a Voilà app if option `
 
 **Voilà dashboards with other language kernels**
 
-Voilà is built upon Jupyter standard formats and protocols, and is agnostic to the programming language of the notebook. In this example, we present an example of a Voilà application powered by the C++ Jupyter kernel [xeus-cling](https://github.com/QuantStack/xeus-cling), and the [xleaflet](https://github.com/QuantStack/xleaflet) project.
+Voilà is built upon Jupyter standard formats and protocols, and is agnostic to the programming language of the notebook. In this example, we present an example of a Voilà application powered by the C++ Jupyter kernel [xeus-cling](https://github.com/jupyter-xeus/xeus-cling), and the [xleaflet](https://github.com/jupyter-xeus/xleaflet) project.
 
 ![Voila cling](voila-cling.gif)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,7 +19,7 @@ git clean -fdx
 
 Make sure the `dist/` folder is empty.
 
-1. Update [voila/_version.py](./voila/_version.py) and [environment.yml](./environment.yml) with the new version number (see and [example diff](https://github.com/QuantStack/voila/commit/5c6fd8dd3ea71412ae9c20c25248453d22a3b60a))
+1. Update [voila/_version.py](./voila/_version.py) and [environment.yml](./environment.yml) with the new version number (see and [example diff](https://github.com/voila-dashboards/voila/commit/5c6fd8dd3ea71412ae9c20c25248453d22a3b60a))
 2. `python setup.py sdist bdist_wheel`
 3. Double check the size of the bundles in the `dist/` folder
 4. Run the tests

--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -228,7 +228,7 @@ configured to use a specific kernel for each language::
      --VoilaConfiguration.language_kernel_mapping='{"python": "xpython"}'
 
 In this case it will use the `xeus-python
-<https://github.com/QuantStack/xeus-python/>`_. kernel to run `.py` files.
+<https://github.com/jupyter-xeus/xeus-python/>`_. kernel to run `.py` files.
 
 Note that the script will be executed as notebook with a single cell, meaning
 that only the last expression will be printed as output. Use the Jupyter

--- a/docs/source/using.rst
+++ b/docs/source/using.rst
@@ -32,7 +32,7 @@ For example, to render the ``bqplot`` example notebook as a standalone app, run
 
 .. code-block:: bash
 
-   git clone https://github.com/QuantStack/voila
+   git clone https://github.com/voila-dashboards/voila
    cd voila
    voila notebooks/bqplot.ipynb
 

--- a/packages/jupyterlab-voila/package.json
+++ b/packages/jupyterlab-voila/package.json
@@ -7,9 +7,9 @@
     "jupyterlab",
     "jupyterlab-extension"
   ],
-  "homepage": "https://github.com/QuantStack/voila",
+  "homepage": "https://github.com/voila-dashboards/voila",
   "bugs": {
-    "url": "https://github.com/QuantStack/voila/issues"
+    "url": "https://github.com/voila-dashboards/voila/issues"
   },
   "license": "BSD-3-Clause",
   "author": "Voila contributors",
@@ -22,7 +22,7 @@
   "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/QuantStack/voila.git"
+    "url": "https://github.com/voila-dashboards/voila.git"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
A couple of places (including the docs) still had references to the `QuantStack` organization.

Replaced by `jupyter-xeus` and `voila-dashboards`.