### PR TITLE
fix: prevent scaling down the viewport on mobile devices

### DIFF
--- a/share/jupyter/voila/templates/default/nbconvert_templates/base.tpl
+++ b/share/jupyter/voila/templates/default/nbconvert_templates/base.tpl
@@ -6,6 +6,7 @@
 <head>
 {%- block html_head -%}
 <meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 {% set nb_title = nb.metadata.get('title', '') or resources['metadata']['name'] %}
 <title>Voila: {{nb_title}}</title>
 


### PR DESCRIPTION
This way the right breakpoint for the screen size on mobile devices
will be used.

With the use of a breakpoint at 960px for showing the two elements side by side

Without this PR:
<img width="448" alt="Schermafbeelding 2020-04-16 om 17 05 50" src="https://user-images.githubusercontent.com/46192475/79474143-55734c00-8006-11ea-91f2-b8d2d0747131.png">

With this PR:
<img width="404" alt="Schermafbeelding 2020-04-16 om 17 06 05" src="https://user-images.githubusercontent.com/46192475/79474091-47bdc680-8006-11ea-9bb0-13c0b2fb7040.png">