### PR TITLE
Docs: using nginx we do not want buffering

### DIFF
--- a/docs/source/deploy.rst
+++ b/docs/source/deploy.rst
@@ -241,6 +241,7 @@ Steps
         server {
             listen 80;
             server_name yourdomain.com;
+            proxy_buffering off;
             location / {
                     proxy_pass http://localhost:8866;
                     proxy_set_header Host $host;


### PR DESCRIPTION
Otherwise, we don't see the progress indicators. I think the example can be improved to allow buffering for static content, but I think this example is an improvement.