### PR TITLE
Show the list of voila kernels in the running tabs

### DIFF
--- a/packages/jupyterlab-voila/package.json
+++ b/packages/jupyterlab-voila/package.json
@@ -38,6 +38,9 @@
     "@jupyterlab/fileeditor": "^2.0.0",
     "@jupyterlab/mainmenu": "^2.0.0",
     "@jupyterlab/notebook": "^2.0.0",
+    "@jupyterlab/running": "^2.1.1",
+    "@jupyterlab/services": "^5.0.0",
+    "@jupyterlab/ui-components": "^2.1.1",
     "react": "~16.9.0",
     "react-dom": "~16.9.0"
   },

--- a/packages/jupyterlab-voila/yarn.lock
+++ b/packages/jupyterlab-voila/yarn.lock
@@ -119,6 +119,31 @@
     react-dom "~16.9.0"
     sanitize-html "~1.20.1"
 
+"@jupyterlab/apputils@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/apputils/-/apputils-2.1.1.tgz#069dc8214261c01c9e2ef58209137430649d4c01"
+  integrity sha512-orGzvW2S1k/FjW42dhygq8XJZbQRBTsNXXKFWsqewSn9sNTd3irKjDEwS3Ilce1w+LsS/t3H03xCnsOYPu8LSQ==
+  dependencies:
+    "@jupyterlab/coreutils" "^4.1.0"
+    "@jupyterlab/services" "^5.1.0"
+    "@jupyterlab/settingregistry" "^2.1.0"
+    "@jupyterlab/statedb" "^2.1.0"
+    "@jupyterlab/ui-components" "^2.1.1"
+    "@lumino/algorithm" "^1.2.3"
+    "@lumino/commands" "^1.10.1"
+    "@lumino/coreutils" "^1.4.2"
+    "@lumino/disposable" "^1.3.5"
+    "@lumino/domutils" "^1.1.7"
+    "@lumino/messaging" "^1.3.3"
+    "@lumino/properties" "^1.1.6"
+    "@lumino/signaling" "^1.3.5"
+    "@lumino/virtualdom" "^1.6.1"
+    "@lumino/widgets" "^1.11.1"
+    "@types/react" "~16.9.16"
+    react "~16.9.0"
+    react-dom "~16.9.0"
+    sanitize-html "~1.20.1"
+
 "@jupyterlab/attachments@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@jupyterlab/attachments/-/attachments-2.1.0.tgz#86dd6c02a0ac2e5b6c1221056bed67bd4d933de1"
@@ -392,7 +417,19 @@
     lodash.escape "^4.0.1"
     marked "^0.8.0"
 
-"@jupyterlab/services@^5.1.0":
+"@jupyterlab/running@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/running/-/running-2.1.1.tgz#232029d96e671d8d0b73ad1335220438d6e3ff3d"
+  integrity sha512-4gzXDIq7UWeVDPjVaOZNz7hB5KnFqy1AscjkCCCCEqSEDp3L6te4e5vkni34CpVKiLDaL0ts2IKcY9omSBcFKw==
+  dependencies:
+    "@jupyterlab/apputils" "^2.1.1"
+    "@jupyterlab/ui-components" "^2.1.1"
+    "@lumino/coreutils" "^1.4.2"
+    "@lumino/disposable" "^1.3.5"
+    "@lumino/signaling" "^1.3.5"
+    react "~16.9.0"
+
+"@jupyterlab/services@^5.0.0", "@jupyterlab/services@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@jupyterlab/services/-/services-5.1.0.tgz#891607d87cbe9413219cfe4ceb9905193b85b657"
   integrity sha512-xhtDvAdgw+sWNSbpkExCYyJbHxlwhiZYqc07+zhOdYrpxO19k/ZmmyNoYCyfvNLcMQ4JWVBoczI714u1QNLj4w==
@@ -459,6 +496,22 @@
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@jupyterlab/ui-components/-/ui-components-2.1.0.tgz#bf718a03845fca93c2088c361f87c80007ea0596"
   integrity sha512-EuIMnm3nKwRBb2VJ1vrKGqd97cQ4jSpytmAqVwQbDhXzatnDDjknvky/f8hwCCOZHdod5EcehgdpgrbIqYYmvQ==
+  dependencies:
+    "@blueprintjs/core" "^3.22.2"
+    "@blueprintjs/select" "^3.11.2"
+    "@jupyterlab/coreutils" "^4.1.0"
+    "@lumino/coreutils" "^1.4.2"
+    "@lumino/signaling" "^1.3.5"
+    "@lumino/virtualdom" "^1.6.1"
+    "@lumino/widgets" "^1.11.1"
+    react "~16.9.0"
+    react-dom "~16.9.0"
+    typestyle "^2.0.4"
+
+"@jupyterlab/ui-components@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/ui-components/-/ui-components-2.1.1.tgz#ace65290ebe3e913e85e574d5d94f3c9f55d244c"
+  integrity sha512-VZWtJud5XXzSTK6HJebbqg7TkJmvuRk5K+F30u+pgX7PStC4j8OFD7IXCreLWmrvxoVvEXd4GFH2sVng5cgsQA==
   dependencies:
     "@blueprintjs/core" "^3.22.2"
     "@blueprintjs/select" "^3.11.2"

--- a/share/jupyter/voila/templates/classic/index.html.j2
+++ b/share/jupyter/voila/templates/classic/index.html.j2
@@ -22,7 +22,7 @@
     {%- set kernel_id = kernel_start() -%}
     <script id="jupyter-config-data" type="application/json">
     {
-        "baseUrl": "{{resources.base_url}}",
+        "baseUrl": "{{resources.base_url}}voila/",
         "kernelId": "{{kernel_id}}"
     }
     </script>

--- a/share/jupyter/voila/templates/lab/index.html.j2
+++ b/share/jupyter/voila/templates/lab/index.html.j2
@@ -35,7 +35,7 @@ var voila_process = function(cell_index, cell_count) {
   {%- with kernel_id = kernel_start() -%}
     <script id="jupyter-config-data" type="application/json">
     {
-        "baseUrl": "{{resources.base_url}}",
+        "baseUrl": "{{resources.base_url}}voila/",
         "kernelId": "{{kernel_id}}"
     }
     </script>

--- a/voila/app.py
+++ b/voila/app.py
@@ -40,7 +40,7 @@ from traitlets.config.loader import Config
 from traitlets import Unicode, Integer, Bool, Dict, List, default
 
 from jupyter_server.services.kernels.kernelmanager import AsyncMappingKernelManager
-from jupyter_server.services.kernels.handlers import KernelHandler, ZMQChannelsHandler
+from jupyter_server.services.kernels.handlers import MainKernelHandler, KernelHandler, ZMQChannelsHandler
 from jupyter_server.services.contents.largefilemanager import LargeFileManager
 from jupyter_server.base.handlers import FileFindHandler, path_regex
 from jupyter_server.config_manager import recursive_update
@@ -70,6 +70,12 @@ _kernel_id_regex = r"(?P<kernel_id>\w+-\w+-\w+-\w+-\w+)"
 
 def _(x):
     return x
+
+
+class VoilaMainKernelHandler(MainKernelHandler):
+    @property
+    def kernel_manager(self):
+        return self.settings['voila_kernel_manager']
 
 
 class VoilaKernelHandler(KernelHandler):
@@ -589,6 +595,7 @@ class Voila(Application):
 main = Voila.launch_instance
 
 base_handlers = [
+    (r'/voila/api/kernels', VoilaMainKernelHandler),
     (r'/voila/api/kernels/%s' % _kernel_id_regex, VoilaKernelHandler),
     (r'/voila/api/kernels/%s/channels' % _kernel_id_regex, VoilaZMQChannelsHandler),
 ]

--- a/voila/app.py
+++ b/voila/app.py
@@ -400,6 +400,7 @@ class Voila(Application):
                 'comm_msg',
                 'comm_info_request',
                 'kernel_info_request',
+                'custom_message',
                 'shutdown_request'
             ]
         )

--- a/voila/app.py
+++ b/voila/app.py
@@ -71,6 +71,7 @@ _kernel_id_regex = r"(?P<kernel_id>\w+-\w+-\w+-\w+-\w+)"
 def _(x):
     return x
 
+
 class VoilaKernelHandler(KernelHandler):
     @property
     def kernel_manager(self):

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -32,6 +32,10 @@ class VoilaHandler(JupyterHandler):
         # we want to avoid starting multiple kernels due to template mistakes
         self.kernel_started = False
 
+    @property
+    def kernel_manager(self):
+        return self.settings['voila_kernel_manager']
+
     @tornado.web.authenticated
     async def get(self, path=None):
         # if the handler got a notebook_path argument, always serve that

--- a/voila/server_extension.py
+++ b/voila/server_extension.py
@@ -75,7 +75,7 @@ def _load_jupyter_server_extension(server_app):
         'voila_configuration': voila_configuration
     }
 
-    handlers =  [
+    handlers = [
         (r'/voila/render/(.*)', VoilaHandler, {
             'config': server_app.config,
             'template_paths': template_paths,

--- a/voila/server_extension.py
+++ b/voila/server_extension.py
@@ -9,18 +9,21 @@
 
 import os
 import gettext
+import tempfile
 
 from jinja2 import Environment, FileSystemLoader
 
 from jupyter_server.utils import url_path_join
 from jupyter_server.base.handlers import path_regex, FileFindHandler
+from jupyter_server.services.kernels.kernelmanager import MappingKernelManager
 
 from .paths import ROOT, collect_template_paths, collect_static_paths, jupyter_path
 from .handler import VoilaHandler
 from .treehandler import VoilaTreeHandler
 from .static_file_handler import MultiStaticFileHandler, WhiteListFileHandler
 from .configuration import VoilaConfiguration
-from .utils import get_server_root_dir
+from .utils import add_base_url_to_handlers, get_server_root_dir
+from .app import base_handlers
 
 
 def _jupyter_server_extension_paths():
@@ -51,23 +54,38 @@ def _load_jupyter_server_extension(server_app):
     nbui = gettext.translation('nbui', localedir=os.path.join(ROOT, 'i18n'), fallback=True)
     env.install_gettext_translations(nbui, newstyle=False)
 
+    connection_dir = tempfile.gettempdir()
+
+    kernel_mapping_manager = MappingKernelManager(
+        connection_dir=connection_dir,
+        allowed_message_types=[
+            'comm_msg',
+            'comm_info_request',
+            'kernel_info_request',
+            'custom_message',
+            'shutdown_request'
+        ]
+    )
+    web_app.settings['voila_kernel_manager'] = kernel_mapping_manager
+
     host_pattern = '.*$'
     base_url = url_path_join(web_app.settings['base_url'])
 
     tree_handler_conf = {
         'voila_configuration': voila_configuration
     }
-    web_app.add_handlers(host_pattern, [
-        (url_path_join(base_url, '/voila/render/(.*)'), VoilaHandler, {
+
+    handlers =  [
+        (r'/voila/render/(.*)', VoilaHandler, {
             'config': server_app.config,
             'template_paths': template_paths,
             'voila_configuration': voila_configuration
         }),
-        (url_path_join(base_url, '/voila'), VoilaTreeHandler, tree_handler_conf),
-        (url_path_join(base_url, '/voila/tree' + path_regex), VoilaTreeHandler, tree_handler_conf),
-        (url_path_join(base_url, '/voila/static/(.*)'), MultiStaticFileHandler, {'paths': static_paths}),
+        (r'/voila', VoilaTreeHandler, tree_handler_conf),
+        (r'/voila/tree' + path_regex, VoilaTreeHandler, tree_handler_conf),
+        (r'/voila/static/(.*)', MultiStaticFileHandler, {'paths': static_paths}),
         (
-            url_path_join(base_url, r'/voila/files/(.*)'),
+            r'/voila/files/(.*)',
             WhiteListFileHandler,
             {
                 'whitelist': voila_configuration.file_whitelist,
@@ -75,7 +93,7 @@ def _load_jupyter_server_extension(server_app):
                 'path': os.path.expanduser(get_server_root_dir(web_app.settings)),
             },
         ),
-    ])
+    ]
 
     # Serving notebook extensions
     if voila_configuration.enable_nbextensions:
@@ -86,10 +104,10 @@ def _load_jupyter_server_extension(server_app):
         else:
             nbextensions_path = jupyter_path('nbextensions')
 
-        web_app.add_handlers(host_pattern, [
+        handlers.extend([
             # this handler serves the nbextensions similar to the classical notebook
             (
-                url_path_join(base_url, r'/voila/nbextensions/(.*)'),
+                r'/voila/nbextensions/(.*)',
                 FileFindHandler,
                 {
                     'path': nbextensions_path,
@@ -97,6 +115,9 @@ def _load_jupyter_server_extension(server_app):
                 },
             )
         ])
+
+    handlers += base_handlers
+    web_app.add_handlers(host_pattern, add_base_url_to_handlers(base_url, handlers))
 
 
 # For backward compatibility

--- a/voila/utils.py
+++ b/voila/utils.py
@@ -1,4 +1,13 @@
+#############################################################################
+# Copyright (c) 2018, Voila Contributors                                    #
+#                                                                           #
+# Distributed under the terms of the BSD 3-Clause License.                  #
+#                                                                           #
+# The full license is in the file LICENSE, distributed with this software.  #
+#############################################################################
+
 import os
+from jupyter_server.utils import url_path_join
 
 
 def get_server_root_dir(settings):
@@ -15,3 +24,8 @@ def get_server_root_dir(settings):
         # collapse $HOME to ~
         root_dir = '~' + root_dir[len(home):]
     return root_dir
+
+
+def add_base_url_to_handlers(base_url, handlers):
+    """Adds the base_url in front of the urls in the Tornado handlers"""
+    return [tuple([url_path_join(base_url, url)] + list(tail)) for url, *tail in handlers]


### PR DESCRIPTION
**EDIT**: this branch depends on https://github.com/voila-dashboards/voila/pull/41. The relevant changes for this current PR are the ones under `packages/jupyterlab-voila/*`. 

### Motivation

Having such list can be useful to get an idea of the number of kernels that are currently running.

It should also help troubleshoot issues such as https://github.com/voila-dashboards/voila/issues/479, https://github.com/voila-dashboards/voila/issues/528, https://github.com/voila-dashboards/voila/issues/562.

### TODO

- [x] Add a new section to the running tabs
- [x] Filter the list of kernels to only show the ones started by Voila (for now it lists all the kernels)

![preview-list-kernels](https://user-images.githubusercontent.com/591645/82434614-6692fb00-9a93-11ea-97fc-5c880821ce42.gif)
