### PR TITLE
Send kernel shutdown request manually on beforeunload

### DIFF
--- a/share/jupyter/voila/templates/base/static/main.js
+++ b/share/jupyter/voila/templates/base/static/main.js
@@ -50,9 +50,12 @@ require([window.voila_js_url || 'static/voila'], function(voila) {
 
         async function init() {
             // it seems if we attach this to early, it will not be called
+            const matches = document.cookie.match('\\b_xsrf=([^;]*)\\b');
+            const xsrfToken = (matches && matches[1]) || '';
             window.addEventListener('beforeunload', function (e) {
                 const xhttp = new XMLHttpRequest();
                 xhttp.open("DELETE", `/api/kernels/${kernel.id}`, false);
+                xhttp.setRequestHeader('X-XSRFToken', xsrfToken);
                 xhttp.send();
                 kernel.dispose();
             });

--- a/share/jupyter/voila/templates/base/static/main.js
+++ b/share/jupyter/voila/templates/base/static/main.js
@@ -51,7 +51,9 @@ require([window.voila_js_url || 'static/voila'], function(voila) {
         async function init() {
             // it seems if we attach this to early, it will not be called
             window.addEventListener('beforeunload', function (e) {
-                kernel.shutdown();
+                const xhttp = new XMLHttpRequest();
+                xhttp.open("DELETE", `/api/kernels/${kernel.id}`, false);
+                xhttp.send();
                 kernel.dispose();
             });
             await widgetManager.build_widgets();


### PR DESCRIPTION
cc @maartenbreddels 

This manually sends a `DELETE /api/kernels/<kernel-id>` with async = false

https://www.w3schools.com/js/js_ajax_http_send.asp

Related: https://github.com/voila-dashboards/voila/issues/528 https://github.com/voila-dashboards/voila/issues/55

![kernel-shutdown-page-refresh](https://user-images.githubusercontent.com/591645/82449210-28a1d100-9aab-11ea-9c6a-2e59d698f706.gif)