### PR TITLE
Prompt before open_voila.

### DIFF
--- a/voila/static/extension.js
+++ b/voila/static/extension.js
@@ -11,8 +11,23 @@ define(['jquery', 'base/js/namespace'], function($, Jupyter) {
     "use strict";
     var open_voila = function() {
         Jupyter.notebook.save_notebook().then(function () {
-            let voila_url = Jupyter.notebook.base_url + "voila/render/" + Jupyter.notebook.notebook_path;
-            window.open(voila_url)
+            var that = this;
+            IPython.dialog.modal({
+                title : "Render notebook with voila",
+                body : $("<p/>").text(
+                    'Render notebook with voila will execute all cells, are you sure to continue?'
+                ),
+                buttons : {
+                    "Edit notebook" : {},
+                    "Render with voila" : {
+                        "class" : "btn-danger",
+                        "click" : function() {
+                            let voila_url = Jupyter.notebook.base_url + "voila/render/" + Jupyter.notebook.notebook_path;
+                            window.open(voila_url);
+                        }
+                    }
+                }
+            });
         });
     }
     var load_ipython_extension = function() {


### PR DESCRIPTION
Prompt before open_voila to avoid accidentally trigger voila button.
Because some temporary cells would contain commands such as "!rm file.csv", thus executing all cells would cause data loss.