### PR TITLE
Spacing and other formatting to docs, avoids build warnings

### DIFF
--- a/docs/source/_static/main_stylesheet.css
+++ b/docs/source/_static/main_stylesheet.css
@@ -1,4 +1,8 @@
-.wy-nav-content{
+.wy-nav-content {
     max-width: 1000px;
     margin: auto;
+}
+
+.wy-nav-content img {
+    margin: 5px auto 25px;
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@ html_theme_options = {
 }
 
 def setup(app):
-    app.add_stylesheet("main_stylesheet.css")
+    app.add_css_file("main_stylesheet.css")
 
 extensions = [
     'sphinx.ext.autodoc',
@@ -38,7 +38,7 @@ html_static_path = ['_static']
 source_suffix = '.rst'
 master_doc = 'index'
 project = 'voila'
-copyright = u'2018, The Voila Development Team'
+copyright = u'2020, The Voila Development Team'
 author = u'The Voila Development Team'
 version = '.'.join(map(str, _release['version_info'][:2]))
 release = _release['__version__']

--- a/docs/source/contribute.rst
+++ b/docs/source/contribute.rst
@@ -5,7 +5,7 @@
    
    The full license is in the file LICENSE, distributed with this software.
 
-.. _install:
+.. _contribute:
 
 =====================
 Contributing to Voilà

--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -121,7 +121,9 @@ Next, we'll copy over the base template files for Voilà, which we'll modify::
     cp -r path/to/env/share/jupyter/voila/templates/default/nbconvert_templates ./
     cp -r path/to/env/share/jupyter/voila/templates/default/templates ./
 
-We should now have a folder structure like this::
+We should now have a folder structure like this:
+
+.. code-block:: bash
 
     tree .
     ├── nbconvert_templates

--- a/docs/source/deploy.rst
+++ b/docs/source/deploy.rst
@@ -35,7 +35,7 @@ Setup an example project
    We omit xleaflet and xeus-cling because these require extra work that is
    beyond the scope of this guide.
 
-   .. code:: txt
+   .. code:: text
 
        bqplot
        ipympl
@@ -111,20 +111,20 @@ High level instructions, specific to voila can be found below:
 2. Add a file named runtime.txt to the project directory with the following
    content:
 
-   .. code:: txt
+   .. code:: text
 
        python-3.7.3
 
 3. Add a file named Procfile to the project directory with the
    following content if you want to show all notebooks:
 
-   ::
+   .. code:: text
 
        web: voila —-port=$PORT --no-browser
 
    Or the following if you only want to show one notebook:
 
-   ::
+   .. code:: text
 
        web: voila —-port=$PORT —-no-browser your_notebook.ipynb
 
@@ -370,7 +370,8 @@ Sharing Voilà applications with ngrok
 `ngrok <https://ngrok.com>`__ is a useful tool to expose local servers to the public internet over secure tunnels.
 It can be used to share Voilà applications served by a local instance of Voilà.
 
-The main use case for using Voilà with ngrok is to quickly share a notebook as an interactive application with
+The main use case for using Voilà with ngrok is to quickly share a notebook as an interactive application without 
+having to deploy to external hosting.
 
 .. warning::
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,24 +8,26 @@
 .. image:: voila-logo.svg
    :alt: voila
 
-From notebooks to standalone web applications and dashboards.
+
+
+
+*From notebooks to standalone web applications and dashboards.*
 
 Voilà allows you to convert a Jupyter Notebook into an
 interactive dashboard that allows you to share your work with others. It
 is secure and customizable, giving you control over what your readers
 experience.
 
-For example, here's a dashboard created with Voilà. (you can
+For example, here's a dashboard created with Voilà. (You can
 try it interactively at the following Binder link)
 
 .. image:: https://mybinder.org/badge_logo.svg
    :target: https://mybinder.org/v2/gh/voila-dashboards/voila/stable?urlpath=voila%2Ftree%2Fnotebooks
 
-.. raw:: html
-
-   <br />
 
 .. image:: ../../voila-basics.gif
+
+
 
 Table of contents
 =================


### PR DESCRIPTION
As discussed on the call last week, I am keen to have somewhere to link new users to introduce them to Voila.

I have made some small formatting to the docs to make them better as a starting point - just some spacing around the images on the first page.

I have also cleaned up other minor aspects of the docs to avoid build warnings and make the build more consistent.