### PR TITLE
Feature: template and theme override

### DIFF
--- a/share/jupyter/voila/templates/base/static/main.js
+++ b/share/jupyter/voila/templates/base/static/main.js
@@ -7,7 +7,7 @@
 ****************************************************************************/
 
 // NOTE: this file is not transpiled, async/await is the only modern feature we use here
-require(['static/voila'], function(voila) {
+require([window.voila_js_url || 'static/voila'], function(voila) {
     // requirejs doesn't like to be passed an async function, so create one inside
     (async function() {
         var kernel = await voila.connectKernel()

--- a/share/jupyter/voila/templates/base/voila_setup.macro.html.j2
+++ b/share/jupyter/voila/templates/base/voila_setup.macro.html.j2
@@ -6,9 +6,10 @@
 </script>
 <script>
 requirejs.config({ baseUrl: '{{base_url}}voila/', waitSeconds: 30})
+window.voila_js_url = "{{ static_url('voila.js')}}"
 requirejs(
     [
-        "static/main",
+        "{{ static_url('main.js') }}",
     {% for ext in nbextensions -%}
         "{{base_url}}voila/nbextensions/{{ ext }}.js",
     {% endfor %}

--- a/share/jupyter/voila/templates/lab/index.html.j2
+++ b/share/jupyter/voila/templates/lab/index.html.j2
@@ -1,7 +1,7 @@
 {%- extends 'nbconvert/templates/lab/index.html.j2' -%}
 {% import "spinner.macro.html.j2" as spinner %}
 {% import "log.macro.html.j2" as log %}
-{% from 'voila_setup.macro.html.j2' import voila_setup %}
+{% from 'voila_setup.macro.html.j2' import voila_setup with context %}
 
 {%- block html_head_js -%}
 {%- block html_head_js_logs -%}

--- a/tests/app/static_files_test.py
+++ b/tests/app/static_files_test.py
@@ -1,0 +1,40 @@
+import pytest
+import tornado
+
+from voila.static_file_handler import TemplateStaticFileHandler
+
+
+async def test_static_file_absolute_path(voila_app, app, base_url, http_server_client):
+    response_lab = await http_server_client.fetch(f'{base_url}voila/templates/lab/static/voila.js')
+    assert response_lab.code == 200
+    abspath = TemplateStaticFileHandler.get_absolute_path(None, 'lab/static/voila.js')
+    with open(abspath) as f:
+        content = f.read()
+    assert response_lab.body.decode('utf-8') == content
+
+
+async def test_static_file_not_found(voila_app, app, base_url, http_server_client):
+    with pytest.raises(tornado.httpclient.HTTPClientError, match='HTTP 404.*'):
+        await http_server_client.fetch(f'{base_url}voila/templates/lab/static/doesnotexist.js')
+
+
+async def test_static_file_availability_default(voila_app, app, base_url, http_server_client):
+    response_lab = await http_server_client.fetch(f'{base_url}voila/templates/lab/static/voila.js')
+    response_default = await http_server_client.fetch(f'{base_url}voila/static/voila.js')
+    assert response_lab.code == 200
+    assert response_default.code == 200
+    assert response_lab.body.decode('utf-8') == response_default.body.decode('utf-8')
+
+
+async def test_static_file_override(voila_app, app, base_url, http_server_client):
+    response_lab = await http_server_client.fetch(f'{base_url}voila/templates/lab/static/voila.js')
+    response_test_template = await http_server_client.fetch(f'{base_url}voila/templates/test_template/static/voila.js')
+    assert response_lab.code == 200
+    assert response_test_template.code == 200
+    assert response_lab.body.decode('utf-8') != response_test_template.body.decode('utf-8')
+
+
+async def test_static_file_other_template(voila_app, app, base_url, http_server_client):
+    response = await http_server_client.fetch(f'{base_url}voila/templates/test_template/static/only-in-test-template.js')
+    assert response.code == 200
+    assert response.body.decode('utf-8') == '', "empty file expected"

--- a/tests/app/template_cli_test.py
+++ b/tests/app/template_cli_test.py
@@ -10,7 +10,7 @@ BASE_DIR = os.path.dirname(__file__)
 def voila_args_extra():
     path_test_template = os.path.abspath(os.path.join(BASE_DIR, '../test_template/share/jupyter/voila/templates/test_template/'))
     path_default = os.path.abspath(os.path.join(BASE_DIR, '../../share/jupyter/voila/templates/default'))
-    return ['--template=None', '--VoilaTest.template_paths=[%r, %r]' % (path_test_template, path_default), '--VoilaExecutor.timeout=240']
+    return ['--template=test_template', '--VoilaTest.template_paths=[%r, %r]' % (path_test_template, path_default), '--VoilaExecutor.timeout=240']
 
 
 async def test_template_test(http_server_client, base_url):

--- a/tests/app/template_custom_test.py
+++ b/tests/app/template_custom_test.py
@@ -8,7 +8,7 @@ BASE_DIR = os.path.dirname(__file__)
 
 @pytest.fixture
 def voila_args_extra():
-    return ['--template=None', '--VoilaExecutor.timeout=240']
+    return ['--template=test_template', '--VoilaExecutor.timeout=240']
 
 
 @pytest.fixture

--- a/tests/server/static_files_test.py
+++ b/tests/server/static_files_test.py
@@ -1,0 +1,40 @@
+import pytest
+import tornado
+
+from voila.static_file_handler import TemplateStaticFileHandler
+
+
+async def test_static_file_absolute_path(app, base_url, http_server_client):
+    response_lab = await http_server_client.fetch(f'{base_url}voila/templates/lab/static/voila.js')
+    assert response_lab.code == 200
+    abspath = TemplateStaticFileHandler.get_absolute_path(None, 'lab/static/voila.js')
+    with open(abspath) as f:
+        content = f.read()
+    assert response_lab.body.decode('utf-8') == content
+
+
+async def test_static_file_not_found(app, base_url, http_server_client):
+    with pytest.raises(tornado.httpclient.HTTPClientError, match='HTTP 404.*'):
+        await http_server_client.fetch(f'{base_url}voila/templates/lab/static/doesnotexist.js')
+
+
+async def test_static_file_availability_default(app, base_url, http_server_client):
+    response_lab = await http_server_client.fetch(f'{base_url}voila/templates/lab/static/voila.js')
+    response_default = await http_server_client.fetch(f'{base_url}voila/static/voila.js')
+    assert response_lab.code == 200
+    assert response_default.code == 200
+    assert response_lab.body.decode('utf-8') == response_default.body.decode('utf-8')
+
+
+async def test_static_file_override(app, base_url, http_server_client):
+    response_lab = await http_server_client.fetch(f'{base_url}voila/templates/lab/static/voila.js')
+    response_test_template = await http_server_client.fetch(f'{base_url}voila/templates/test_template/static/voila.js')
+    assert response_lab.code == 200
+    assert response_test_template.code == 200
+    assert response_lab.body.decode('utf-8') != response_test_template.body.decode('utf-8')
+
+
+async def test_static_file_other_template(app, base_url, http_server_client):
+    response = await http_server_client.fetch(f'{base_url}voila/templates/test_template/static/only-in-test-template.js')
+    assert response.code == 200
+    assert response.body.decode('utf-8') == '', "empty file expected"

--- a/tests/test_template/share/jupyter/voila/templates/test_template/static/voila.js
+++ b/tests/test_template/share/jupyter/voila/templates/test_template/static/voila.js
@@ -1,0 +1,1 @@
+// this file overrides the default voila.js

--- a/voila/app.py
+++ b/voila/app.py
@@ -57,7 +57,7 @@ from .paths import ROOT, STATIC_ROOT, collect_template_paths, collect_static_pat
 from .handler import VoilaHandler
 from .treehandler import VoilaTreeHandler
 from ._version import __version__
-from .static_file_handler import MultiStaticFileHandler, WhiteListFileHandler
+from .static_file_handler import MultiStaticFileHandler, TemplateStaticFileHandler, WhiteListFileHandler
 from .configuration import VoilaConfiguration
 from .execute import VoilaExecutor
 from .exporter import VoilaExporter
@@ -427,13 +427,17 @@ class Voila(Application):
             (url_path_join(self.server_url, r'/api/kernels/%s' % _kernel_id_regex), KernelHandler),
             (url_path_join(self.server_url, r'/api/kernels/%s/channels' % _kernel_id_regex), ZMQChannelsHandler),
             (
+                url_path_join(self.server_url, r'/voila/templates/(.*)'),
+                TemplateStaticFileHandler
+            ),
+            (
                 url_path_join(self.server_url, r'/voila/static/(.*)'),
                 MultiStaticFileHandler,
                 {
                     'paths': self.static_paths,
                     'default_filename': 'index.html'
-                }
-            )
+                },
+            ),
         ])
 
         # Serving notebook extensions

--- a/voila/configuration.py
+++ b/voila/configuration.py
@@ -16,6 +16,9 @@ class VoilaConfiguration(traitlets.config.Configurable):
     allow_template_override = Enum(['YES', 'NOTEBOOK', 'NO'], 'YES', help='''
     Allow overriding the template (YES), or not (NO), or only from the notebook metadata.
     ''').tag(config=True)
+    allow_theme_override = Enum(['YES', 'NOTEBOOK', 'NO'], 'YES', help='''
+    Allow overriding the theme (YES), or not (NO), or only from the notebook metadata.
+    ''').tag(config=True)
     template = Unicode(
         'lab',
         config=True,

--- a/voila/configuration.py
+++ b/voila/configuration.py
@@ -8,11 +8,14 @@
 #############################################################################
 
 import traitlets.config
-from traitlets import Unicode, Bool, Dict, List, Int
+from traitlets import Unicode, Bool, Dict, List, Int, Enum
 
 
 class VoilaConfiguration(traitlets.config.Configurable):
     """Common configuration options between the server extension and the application."""
+    allow_template_override = Enum(['YES', 'NOTEBOOK', 'NO'], 'YES', help='''
+    Allow overriding the template (YES), or not (NO), or only from the notebook metadata.
+    ''').tag(config=True)
     template = Unicode(
         'lab',
         config=True,

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -91,11 +91,17 @@ class VoilaHandler(JupyterHandler):
             self.template_paths = collect_template_paths(['voila', 'nbconvert'], template_override)
         template_name = template_override or self.voila_configuration.template
 
+        theme = self.voila_configuration.theme
+        if 'voila' in notebook.metadata and self.voila_configuration.allow_theme_override in ['YES', 'NOTEBOOK']:
+            theme = notebook.metadata['voila'].get('theme', theme)
+        if self.voila_configuration.allow_theme_override == 'YES':
+            theme = self.get_argument("voila-theme", theme)
+
         # render notebook to html
         resources = {
             'base_url': self.base_url,
             'nbextensions': nbextensions,
-            'theme': self.voila_configuration.theme,
+            'theme': theme,
             'template': template_name,
             'metadata': {
                 'name': notebook_name
@@ -116,7 +122,7 @@ class VoilaHandler(JupyterHandler):
             template_name=template_name,
             config=self.traitlet_config,
             contents_manager=self.contents_manager,  # for the image inlining
-            theme=self.voila_configuration.theme,  # we now have the theme in two places
+            theme=theme,  # we now have the theme in two places
             base_url=self.base_url,
         )
         if self.voila_configuration.strip_sources:

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -237,7 +237,7 @@ class VoilaHandler(JupyterHandler):
         if 'voila' in notebook.metadata:
             tplname = notebook.metadata['voila'].get('template')
             if tplname:
-                self.nbconvert_template_paths = collect_template_paths(['voila', 'nbconvert'], tplname) + self.nbconvert_template_paths
+                self.template_paths = collect_template_paths(['voila', 'nbconvert'], tplname) + self.template_paths
 
         # Fetch kernel name from the notebook metadata
         if 'kernelspec' not in notebook.metadata:

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -27,7 +27,7 @@ from tornado.httputil import split_host_and_port
 from ._version import __version__
 from .execute import VoilaExecutor, strip_code_cell_warnings
 from .exporter import VoilaExporter
-
+from .paths import collect_template_paths
 
 class VoilaHandler(JupyterHandler):
 
@@ -234,6 +234,10 @@ class VoilaHandler(JupyterHandler):
 
         In case the kernel is not found, we search for a matching kernel based on the language.
         """
+        if 'voila' in notebook.metadata:
+            tplname = notebook.metadata['voila'].get('template')
+            if tplname:
+                self.nbconvert_template_paths = collect_template_paths(['voila', 'nbconvert'], tplname) + self.nbconvert_template_paths
 
         # Fetch kernel name from the notebook metadata
         if 'kernelspec' not in notebook.metadata:

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -29,6 +29,7 @@ from .execute import VoilaExecutor, strip_code_cell_warnings
 from .exporter import VoilaExporter
 from .paths import collect_template_paths
 
+
 class VoilaHandler(JupyterHandler):
 
     def initialize(self, **kwargs):

--- a/voila/server_extension.py
+++ b/voila/server_extension.py
@@ -18,7 +18,7 @@ from jupyter_server.base.handlers import path_regex, FileFindHandler
 from .paths import ROOT, collect_template_paths, collect_static_paths, jupyter_path
 from .handler import VoilaHandler
 from .treehandler import VoilaTreeHandler
-from .static_file_handler import MultiStaticFileHandler, WhiteListFileHandler
+from .static_file_handler import MultiStaticFileHandler, TemplateStaticFileHandler, WhiteListFileHandler
 from .configuration import VoilaConfiguration
 from .utils import get_server_root_dir
 
@@ -65,6 +65,7 @@ def _load_jupyter_server_extension(server_app):
         }),
         (url_path_join(base_url, '/voila'), VoilaTreeHandler, tree_handler_conf),
         (url_path_join(base_url, '/voila/tree' + path_regex), VoilaTreeHandler, tree_handler_conf),
+        (url_path_join(base_url, '/voila/templates/(.*)'), TemplateStaticFileHandler),
         (url_path_join(base_url, '/voila/static/(.*)'), MultiStaticFileHandler, {'paths': static_paths}),
         (
             url_path_join(base_url, r'/voila/files/(.*)'),

--- a/voila/static_file_handler.py
+++ b/voila/static_file_handler.py
@@ -12,6 +12,59 @@ import re
 
 import tornado.web
 
+from .paths import collect_static_paths
+
+
+class TemplateStaticFileHandler(tornado.web.StaticFileHandler):
+    """Static file handler that serves the static files for the template system.
+
+    URL paths should be of the form <`template_name>/static/<path>`
+
+    A url such as lab/static/voila.js can be translated to a real path such
+    /my/prefix/jupyter/voila/templates/base/static/voila.js
+    Meaning the url portion is not part of the real (absolute path)
+
+    For this sytem, we don't need to use the root, since this is handled in the
+    paths module.
+    """
+    def initialize(self):
+        super().initialize(path='/fake-root/voila-template-system/')
+
+    def parse_url_path(self, path):
+        # since we cannot determine the template from validate_absolute_path
+        # we get all possible roots here:
+        template, static, _ignore = path.split('/', 2)
+        assert static == 'static'
+        self.roots = collect_static_paths(['voila', 'nbconvert'], template)
+        # simply forward the call
+        return super().parse_url_path(path)
+
+    def validate_absolute_path(self, root: str, absolute_path: str):
+        # Instead of comparing to 1 root (self.root), which we don't use
+        # we compare it to all the roots, and only 1 combinations has to be valid
+        last_exception = None
+        for root in self.roots:
+            try:
+                return super().validate_absolute_path(root, absolute_path)
+            except tornado.web.HTTPError as e:
+                last_exception = e
+        assert last_exception
+        raise last_exception
+
+    @classmethod
+    def get_absolute_path(cls, root, path):
+        template, static, relpath = path.split('/', 2)
+        assert static == 'static'
+        roots = collect_static_paths(['voila', 'nbconvert'], template)
+        for root in roots:
+            abspath = os.path.abspath(os.path.join(root, relpath))
+            if os.path.exists(abspath):
+                return abspath
+                break
+        # if we didn't find it, we will simply return an invalid path
+        # which will lead to a 404
+        return abspath
+
 
 class MultiStaticFileHandler(tornado.web.StaticFileHandler):
     """A static file handler that 'merges' a list of directories


### PR DESCRIPTION
Implements #635  Replaces #629, #201 and #258


This allow overriding the template and theme, e.g.:
```
http://localhost:8866/voila/render/basics.ipynb?voila-template=material&voila-theme=dark
```

Or via notebook metadata:
```
....
 "metadata": {
  "voila": {
    "template": "material",
    "theme": "dark"
  },
  "kernelspec": {
   "display_name": "Python 3",
   "language": "python",
....
```

Configuration to disable this:
```
$ voila notebooks/ --VoilaConfiguration.allow_template_override=NO  # never allow this
$ voila notebooks/ --VoilaConfiguration.allow_template_override=NOTEBOOK  # only via notebook metadata
$ voila notebooks/ --VoilaConfiguration.allow_theme_override=NOTEBOOK  # similar for theme
```