### PR TITLE
fix: use template_paths instead of old template_path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -233,7 +233,7 @@ setup_args = {
         'jupyter_server>=0.3.0,<0.4.0',
         'jupyter_client>=6.1.3,<7',
         'nbclient>=0.4.0,<0.5',
-        'nbconvert==6.0.0a3'
+        'nbconvert==6.0.0a4'
     ],
     'extras_require': {
         'test': [

--- a/voila/exporter.py
+++ b/voila/exporter.py
@@ -105,9 +105,6 @@ class VoilaExporter(HTMLExporter):
             env.add_extension('jinja2.ext.do')
         return env
 
-    def get_template_paths(self):
-        return self.template_path
-
     def _init_resources(self, resources):
         def include_css(name):
             code = """<link rel="stylesheet" type="text/css" href="%svoila/%s">""" % (self.base_url, name)

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -82,7 +82,7 @@ class VoilaHandler(JupyterHandler):
             recursive_update(resources, extra_resources)
 
         self.exporter = VoilaExporter(
-            template_path=self.template_paths,
+            template_paths=self.template_paths,
             config=self.traitlet_config,
             contents_manager=self.contents_manager,  # for the image inlining
             theme=self.voila_configuration.theme,  # we now have the theme in two places


### PR DESCRIPTION
In https://github.com/jupyter/nbconvert/pull/1310 we got rid of template_path, and set the template_paths. This also means we don't have to override the get_template_paths since template_paths is a trait, where the old get_template_paths is the default (method).