### PR TITLE
Fix #624 - Broken link in docs

### DIFF
--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -61,7 +61,7 @@ In order to create your own template, first familiarize yourself with **Jinja**,
 **HTML**, and **CSS**. Each of these is used in creating custom templates.
 For more information, see
 `the nbconvert templates documentation <https://nbconvert.readthedocs.io/en/latest/customizing.html#Custom-Templates>`_.
-For one example, `check out the nbconvert basic HTML template <https://github.com/jupyter/nbconvert/blob/master/nbconvert/templates/html/basic.tpl>`_.
+For one example, `check out the nbconvert basic HTML template <https://github.com/jupyter/nbconvert/blob/master/share/jupyter/nbconvert/templates/classic/base.html.j2>`_.
 
 Where are Voilà templates located?
 ----------------------------------


### PR DESCRIPTION
I was reading the template documentation and noticed a dead link.
This was already documented back in may, as per #624: _"if you click ['check out the nbconvert basic HTML template'](https://github.com/jupyter/nbconvert/blob/master/nbconvert/templates/html/basic.tpl) you'll get a 404."_
From what I could gather, the target files were moved in jupyter/nbconvert@f4c7daefe0e24055a92f185d6fd803abf909db2f

The response to the issue suggested the need for a broader update to the documentation _"to reflect the template refactoring that we just merged"_, but in the meantime at least the link is fixed.