### PR TITLE
feat: when a widget fails, show a fallback error widget

### DIFF
--- a/packages/voila/src/errorwidget.ts
+++ b/packages/voila/src/errorwidget.ts
@@ -1,0 +1,30 @@
+import * as widgets from '@jupyter-widgets/base';
+
+// Create a Widget Model that captures an error object
+export function createErrorWidget(error: string): any {
+  class ErrorWidget extends widgets.DOMWidgetModel {
+    constructor(attributes?: any, options?: any) {
+      attributes = {
+        ...attributes,
+        _view_name: 'ErrorWidgetView',
+        _view_module: 'voila-errorwidget',
+        _model_module_version: '1.0.0',
+        _view_module_version: '1.0.0',
+        failed_module: attributes._view_module,
+        failed_model_name: attributes._model_name,
+        error: error
+      };
+      super(attributes, options);
+    }
+  }
+  return ErrorWidget as any;
+}
+
+export class ErrorWidgetView extends widgets.DOMWidgetView {
+  render() {
+    const module = this.model.get('failed_module');
+    const name = this.model.get('failed_model_name');
+    const error = String(this.model.get('error').stack);
+    this.el.innerHTML = `Failed to load widget '${name}' from module '${module}', error:<pre>${error}</pre>`;
+  }
+}


### PR DESCRIPTION
Fixes #657 
Consider this code:
```python
import ipywidgets as widgets
from traitlets import Unicode

class BadWidget(widgets.DOMWidget):
    _model_module = Unicode('badwidget').tag(sync=True)
    _view_module = Unicode('badwidget').tag(sync=True)
    _view_name = Unicode('DoesNotExist').tag(sync=True)
bad_widget = BadWidget()
widgets.HBox([bad_widget, widgets.Button(description='Hi')])
```

This would now render to:

![image](https://user-images.githubusercontent.com/1765949/89188955-9f754300-d59f-11ea-9d9b-8532f615106b.png)


If the semver is off:
```python
import ipywidgets as widgets
from traitlets import Unicode

class BadVersion(widgets.Button):
    _model_module_version = Unicode('11.0').tag(sync=True)
bad_version = BadVersion()
widgets.HBox([bad_version, widgets.Button(description='Hi')])
```

You'd see this:
![image](https://user-images.githubusercontent.com/1765949/89190721-24615c00-d5a2-11ea-826f-ad4681151087.png)


And if the widget model name is off:

```python
import ipywidgets as widgets
import ipyvolume as ipv
from traitlets import Unicode

class BadName(ipv.Figure):
    _model_name = Unicode('Fig').tag(sync=True)
bad_name = BadName()
widgets.HBox([bad_name, widgets.Button(description='Hi')])
```

It renders:

![image](https://user-images.githubusercontent.com/1765949/89190818-4e1a8300-d5a2-11ea-8460-5e318b2d936f.png)



So in all of these cases, something gets rendered. The only case that is not handled, is when the view_name is off (difficult to catch)