### PR TITLE
Remove the call to zmq.eventloop.ioloop.install

### DIFF
--- a/voila/app.py
+++ b/voila/app.py
@@ -7,8 +7,6 @@
 # The full license is in the file LICENSE, distributed with this software.  #
 #############################################################################
 
-from zmq.eventloop import ioloop
-
 import gettext
 import io
 import json
@@ -62,7 +60,6 @@ from .configuration import VoilaConfiguration
 from .execute import VoilaExecutor
 from .exporter import VoilaExporter
 
-ioloop.install()
 _kernel_id_regex = r"(?P<kernel_id>\w+-\w+-\w+-\w+-\w+)"
 
 


### PR DESCRIPTION
It looks like we should be able to remove the call to `zmq.eventloop.ioloop.install`, which has been marked as deprecated since `pyzmq==17`:

https://github.com/zeromq/pyzmq/blob/3cf21b8fb0790e884df04b0ad86ca02233fc0414/zmq/eventloop/ioloop.py#L124-L130

`notebook` and `jupyter_server` use `pyzmq>=17`:

https://github.com/jupyter/notebook/blob/a35b5119912dd6e9201727a46dec10f94f42b6c0/setup.py#L105

https://github.com/jupyter/jupyter_server/blob/097676b64cb9043fd65c19d15d4df2fd9d310d50/setup.py#L40
