### PR TITLE
fix: when using the back button Voila doesn't load

### DIFF
--- a/voila/handler.py
+++ b/voila/handler.py
@@ -147,6 +147,9 @@ class VoilaHandler(JupyterHandler):
 
         # Compose reply
         self.set_header('Content-Type', 'text/html')
+        self.set_header('Cache-Control', 'no-cache, no-store, must-revalidate')
+        self.set_header('Pragma', 'no-cache')
+        self.set_header('Expires', '0')
         # render notebook in snippets, and flush them out to the browser can render progresssively
         async for html_snippet, resources in self.exporter.generate_from_notebook_node(notebook, resources=resources, extra_context=extra_context):
             self.write(html_snippet)


### PR DESCRIPTION
When navigating away and later coming back via the browser back (or forward) button, the Voilà page doesn't load, showing the following error in the console: `Error: No running kernel with id: 24b5b2dd-f00b-4149-80b5-036ae1f471de`

This PR fixes that by preventing the browser to use a cached version of the page with a stale kernel id.