### PR TITLE
fix: do not fail logging when JS object cannot be cloned

### DIFF
--- a/share/jupyter/voila/templates/base/log.macro.html.j2
+++ b/share/jupyter/voila/templates/base/log.macro.html.j2
@@ -6,30 +6,34 @@
     const _warn = console.warn;
     const _error = console.error;
 
-    console.debug = (...args) => {
+    function post(level, args) {
+      try {
         window.top.postMessage({ level: "debug", msg: ["[Voilà]:", ...args] });
+      } catch(err) {
+        window.top.postMessage({ level: "debug", msg: ["[Voilà]:",
+                                                       "Issue cloning object when posting log message, JSON stringify version is:",
+                                                       JSON.stringify(args)
+                                                       ] });
+      }
+    }
+    console.debug = (...args) => {
+        post({ level: "debug", msg: ["[Voilà]:", ...args] });
         _debug(...args);
     };
 
     console.info = console.info = (...args) => {
-        window.top.postMessage({ level: "info", msg: ["[Voilà]:", ...args] });
+        post({ level: "info", msg: ["[Voilà]:", ...args] });
         _info(...args);
     };
 
     console.warn = (...args) => {
-        window.top.postMessage({ level: "warn", msg: ["[Voilà]:", ...args] });
+        post({ level: "warn", msg: ["[Voilà]:", ...args] });
         _warn(...args);
     };
 
     console.error = (...args) => {
-        window.top.postMessage({ level: "error", msg: ["[Voilà]:", ...args] });
+        post({ level: "error", msg: ["[Voilà]:", ...args] });
         _error(...args);
     };
-    
-    //console.log("test");
-    //console.debug("debug");
-    //console.info("info");
-    //console.warn("warn");
-    //console.error("error");
   </script>
 {% endmacro %}


### PR DESCRIPTION
Not all objects logged can be cloned, leading to the error msg:
Uncaught (in promise) DOMException: The object could not be cloned.

Related #729 #693