### PR TITLE
Move require.min.js script element to be above notebook execution

### DIFF
--- a/share/jupyter/voila/templates/base/log.macro.html.j2
+++ b/share/jupyter/voila/templates/base/log.macro.html.j2
@@ -1,13 +1,5 @@
 {% macro js() %}
-
-<!-- voila require js -->
-  <script
-    src="{{base_url}}voila/static/require.min.js"
-    integrity="sha256-Ae2Vz/4ePdIu6ZyI/5ZGsYnb+m0JlOmKPjt6XZ9JJkA="
-    crossorigin="anonymous">
-  </script>
-
-<!-- voila log js -->
+  <!-- voila log js -->
   <script>
     const _debug = console.debug;
     const _info = console.info;

--- a/share/jupyter/voila/templates/base/log.macro.html.j2
+++ b/share/jupyter/voila/templates/base/log.macro.html.j2
@@ -1,5 +1,13 @@
 {% macro js() %}
-  <!-- voila log js -->
+
+<!-- voila require js -->
+  <script
+    src="{{base_url}}voila/static/require.min.js"
+    integrity="sha256-Ae2Vz/4ePdIu6ZyI/5ZGsYnb+m0JlOmKPjt6XZ9JJkA="
+    crossorigin="anonymous">
+  </script>
+
+<!-- voila log js -->
   <script>
     const _debug = console.debug;
     const _info = console.info;

--- a/share/jupyter/voila/templates/base/voila_setup.macro.html.j2
+++ b/share/jupyter/voila/templates/base/voila_setup.macro.html.j2
@@ -1,9 +1,4 @@
 {%- macro voila_setup(base_url, nbextensions) -%}
-<script
-    src="{{base_url}}voila/static/require.min.js"
-    integrity="sha256-Ae2Vz/4ePdIu6ZyI/5ZGsYnb+m0JlOmKPjt6XZ9JJkA="
-    crossorigin="anonymous">
-</script>
 <script>
 requirejs.config({ baseUrl: '{{base_url}}voila/', waitSeconds: 30})
 window.voila_js_url = "{{ static_url('voila.js')}}"

--- a/share/jupyter/voila/templates/classic/index.html.j2
+++ b/share/jupyter/voila/templates/classic/index.html.j2
@@ -5,7 +5,7 @@
 {%- block html_head_js -%}
   <!-- voila require js -->
   <script
-    src="{{base_url}}voila/static/require.min.js"
+    src="{{resources.base_url}}voila/static/require.min.js"
     integrity="sha256-Ae2Vz/4ePdIu6ZyI/5ZGsYnb+m0JlOmKPjt6XZ9JJkA="
     crossorigin="anonymous">
   </script>

--- a/share/jupyter/voila/templates/classic/index.html.j2
+++ b/share/jupyter/voila/templates/classic/index.html.j2
@@ -3,12 +3,13 @@
 {% from 'voila_setup.macro.html.j2' import voila_setup with context %}
 
 {%- block html_head_js -%}
-  <!-- voila require js -->
+  {%- block html_head_js_requirejs -%}
   <script
     src="{{resources.base_url}}voila/static/require.min.js"
     integrity="sha256-Ae2Vz/4ePdIu6ZyI/5ZGsYnb+m0JlOmKPjt6XZ9JJkA="
     crossorigin="anonymous">
   </script>
+  {%- endblock html_head_js_requirejs -%}
 {%- block html_head_js_logs -%}
 {{ log.js() }}
 {%- endblock html_head_js_logs -%}

--- a/share/jupyter/voila/templates/classic/index.html.j2
+++ b/share/jupyter/voila/templates/classic/index.html.j2
@@ -3,6 +3,12 @@
 {% from 'voila_setup.macro.html.j2' import voila_setup with context %}
 
 {%- block html_head_js -%}
+  <!-- voila require js -->
+  <script
+    src="{{base_url}}voila/static/require.min.js"
+    integrity="sha256-Ae2Vz/4ePdIu6ZyI/5ZGsYnb+m0JlOmKPjt6XZ9JJkA="
+    crossorigin="anonymous">
+  </script>
 {%- block html_head_js_logs -%}
 {{ log.js() }}
 {%- endblock html_head_js_logs -%}

--- a/share/jupyter/voila/templates/lab/index.html.j2
+++ b/share/jupyter/voila/templates/lab/index.html.j2
@@ -6,7 +6,7 @@
 {%- block html_head_js -%}
   <!-- voila require js -->
   <script
-    src="{{base_url}}voila/static/require.min.js"
+    src="{{resources.base_url}}voila/static/require.min.js"
     integrity="sha256-Ae2Vz/4ePdIu6ZyI/5ZGsYnb+m0JlOmKPjt6XZ9JJkA="
     crossorigin="anonymous">
   </script>

--- a/share/jupyter/voila/templates/lab/index.html.j2
+++ b/share/jupyter/voila/templates/lab/index.html.j2
@@ -4,6 +4,12 @@
 {% from 'voila_setup.macro.html.j2' import voila_setup with context %}
 
 {%- block html_head_js -%}
+  <!-- voila require js -->
+  <script
+    src="{{base_url}}voila/static/require.min.js"
+    integrity="sha256-Ae2Vz/4ePdIu6ZyI/5ZGsYnb+m0JlOmKPjt6XZ9JJkA="
+    crossorigin="anonymous">
+  </script>
 {%- block html_head_js_logs -%}
 {{ log.js() }}
 {%- endblock html_head_js_logs -%}

--- a/share/jupyter/voila/templates/lab/index.html.j2
+++ b/share/jupyter/voila/templates/lab/index.html.j2
@@ -4,12 +4,13 @@
 {% from 'voila_setup.macro.html.j2' import voila_setup with context %}
 
 {%- block html_head_js -%}
-  <!-- voila require js -->
+  {%- block html_head_js_requirejs -%}
   <script
     src="{{resources.base_url}}voila/static/require.min.js"
     integrity="sha256-Ae2Vz/4ePdIu6ZyI/5ZGsYnb+m0JlOmKPjt6XZ9JJkA="
     crossorigin="anonymous">
   </script>
+  {%- endblock html_head_js_requirejs -%}
 {%- block html_head_js_logs -%}
 {{ log.js() }}
 {%- endblock html_head_js_logs -%}


### PR DESCRIPTION
When base.tpl was reworked into index.html.j2 files, the require.min.js script element was relocated from the top of the page to just above voila's requirejs(), after the notebook cell loads. This removed it from notebook cell scope and breaks plotly (and anything else depending on require.min.js already being called). 

This puts the script element back to where it was by taking it from the voila_setup macro and piggybacking on the logging macro. 

A more principled fix might mirror the logging macro instead of appropriating it.