### PR TITLE
feat: allow showing of stacktraces in server extension mode

### DIFF
--- a/tests/app/show_traceback_test.py
+++ b/tests/app/show_traceback_test.py
@@ -1,0 +1,23 @@
+import pytest
+
+
+@pytest.fixture(params=[True, False])
+def show_tracebacks(request):
+    return request.param
+
+
+@pytest.fixture
+def voila_args(notebook_directory, voila_args_extra, show_tracebacks):
+    return ['--VoilaTest.root_dir=%r' % notebook_directory, f'--VoilaConfiguration.show_tracebacks={show_tracebacks}'] + voila_args_extra
+
+
+async def test_syntax_error(http_server_client, syntax_error_notebook_url, show_tracebacks):
+    response = await http_server_client.fetch(syntax_error_notebook_url)
+    assert response.code == 200
+    output = response.body.decode('utf-8')
+    if show_tracebacks:
+        assert 'this is a syntax error' in output, 'should show the "code"'
+        assert 'SyntaxError' in output and 'invalid syntax' in output, "should show the error"
+    else:
+        assert 'There was an error when executing cell' in output
+        assert 'This should not be executed' not in output

--- a/tests/app/syntax_error_test.py
+++ b/tests/app/syntax_error_test.py
@@ -2,17 +2,12 @@ import pytest
 
 
 @pytest.fixture
-def syntax_error_notebook(base_url):
-    return base_url + "voila/render/syntax_error.ipynb"
-
-
-@pytest.fixture
 def voila_args(notebook_directory, voila_args_extra):
     return ['--VoilaTest.root_dir=%r' % notebook_directory] + voila_args_extra
 
 
-async def test_syntax_error(capsys, http_server_client, syntax_error_notebook):
-    response = await http_server_client.fetch(syntax_error_notebook)
+async def test_syntax_error(capsys, http_server_client, syntax_error_notebook_url):
+    response = await http_server_client.fetch(syntax_error_notebook_url)
     assert response.code == 200
     output = response.body.decode('utf-8')
     assert 'There was an error when executing cell' in output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,5 +18,10 @@ def print_notebook_url(base_url):
 
 
 @pytest.fixture
+def syntax_error_notebook_url(base_url):
+    return base_url + "voila/render/syntax_error.ipynb"
+
+
+@pytest.fixture
 def voila_notebook(notebook_directory):
     return os.path.join(notebook_directory, 'print.ipynb')

--- a/tests/server/show_traceback_test.py
+++ b/tests/server/show_traceback_test.py
@@ -1,0 +1,23 @@
+import pytest
+
+
+@pytest.fixture(params=[True, False])
+def show_tracebacks(request):
+    return request.param
+
+
+@pytest.fixture
+def jupyter_server_args_extra(show_tracebacks):
+    return [f'--VoilaConfiguration.show_tracebacks={show_tracebacks}']
+
+
+async def test_syntax_error(http_server_client, syntax_error_notebook_url, show_tracebacks):
+    response = await http_server_client.fetch(syntax_error_notebook_url)
+    assert response.code == 200
+    output = response.body.decode('utf-8')
+    if show_tracebacks:
+        assert 'this is a syntax error' in output, 'should show the "code"'
+        assert 'SyntaxError' in output and 'invalid syntax' in output, "should show the error"
+    else:
+        assert 'There was an error when executing cell' in output
+        assert 'This should not be executed' not in output

--- a/voila/app.py
+++ b/voila/app.py
@@ -75,7 +75,10 @@ class Voila(Application):
 
     flags = {
         'debug': (
-            {'Voila': {'log_level': logging.DEBUG, 'show_tracebacks': True}},
+            {
+                'Voila': {'log_level': logging.DEBUG},
+                'VoilaConfiguration': {'show_tracebacks': True},
+            },
             _("Set the log level to logging.DEBUG, and show exception tracebacks in output.")
         ),
         'no-browser': ({'Voila': {'open_browser': False}}, _('Don\'t open the notebook in a browser after startup.'))
@@ -125,7 +128,8 @@ class Voila(Application):
         'theme': 'VoilaConfiguration.theme',
         'base_url': 'Voila.base_url',
         'server_url': 'Voila.server_url',
-        'enable_nbextensions': 'VoilaConfiguration.enable_nbextensions'
+        'enable_nbextensions': 'VoilaConfiguration.enable_nbextensions',
+        'show_tracebacks': 'VoilaConfiguration.show_tracebacks',
     }
     classes = [
         VoilaConfiguration,
@@ -186,10 +190,6 @@ class Voila(Application):
             'paths to static assets'
         )
     )
-
-    show_tracebacks = Bool(False, config=True, help=_(
-        'Whether to send tracebacks to clients on exceptions.'
-    ))
 
     port_retries = Integer(50, config=True,
                            help=_("The number of additional ports to try if the specified port is not available.")

--- a/voila/configuration.py
+++ b/voila/configuration.py
@@ -81,3 +81,7 @@ class VoilaConfiguration(traitlets.config.Configurable):
     When a cell takes a long time to execute, the http connection can timeout (possibly because of a proxy).
     Voila sends a 'heartbeat' message after the timeout is passed to keep the http connection alive.
     """).tag(config=True)
+
+    show_tracebacks = Bool(False, config=True, help=(
+        'Whether to send tracebacks to clients on exceptions.'
+    ))

--- a/voila/execute.py
+++ b/voila/execute.py
@@ -11,7 +11,7 @@ from nbconvert.preprocessors import ClearOutputPreprocessor
 from nbclient.exceptions import CellExecutionError
 from nbclient import NotebookClient
 
-from traitlets import Unicode
+from traitlets import Bool, Unicode
 
 
 def strip_code_cell_warnings(cell):
@@ -32,7 +32,7 @@ def strip_code_cell_warnings(cell):
 class VoilaExecutor(NotebookClient):
     """Execute, but respect the output widget behaviour"""
     cell_error_instruction = Unicode(
-        'Please run Voilà with --debug to see the error message.',
+        'Please run Voilà with --show_tracebacks=True or --debug to see the error message, or configure VoilaConfigurion.show_tracebacks.',
         config=True,
         help=(
             'instruction given to user to debug cell errors'
@@ -46,6 +46,10 @@ class VoilaExecutor(NotebookClient):
             'instruction given to user to continue execution on timeout'
         )
     )
+
+    show_tracebacks = Bool(False, config=True, help=(
+        'Whether to send tracebacks to clients on exceptions.'
+    ))
 
     def execute(self, nb, resources, km=None):
         try:
@@ -77,7 +81,7 @@ class VoilaExecutor(NotebookClient):
 
     def should_strip_error(self):
         """Return True if errors should be stripped from the Notebook, False otherwise, depending on the current config."""
-        return 'Voila' not in self.config or not self.config['Voila'].get('show_tracebacks', False)
+        return not self.show_tracebacks
 
     def strip_notebook_errors(self, nb):
         """Strip error messages and traceback from a Notebook."""

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -170,7 +170,8 @@ class VoilaHandler(JupyterHandler):
         ))
         km = self.kernel_manager.get_kernel(kernel_id)
 
-        self.executor = VoilaExecutor(nb, km=km, config=self.traitlet_config)
+        self.executor = VoilaExecutor(nb, km=km, config=self.traitlet_config,
+                                      show_tracebacks=self.voila_configuration.show_tracebacks)
 
         ###
         # start kernel client


### PR DESCRIPTION
Closes #751
This is a followup of #630

@vidartf @: this is breaking in the sense of configuration `Voila.show_tracebacks` does not work anymore (if should now be `VoilaConfiguration.show_tracebacks`, *but* running voila with `voila --show_tracebacks=True` does still work (it is an alias). Should we consider this a breaking change, and up the minor version number (pre 1.0).
cc @aschlaep

Note that we could have skipped the `VoilaConfiguration.show_tracebacks` and only use `VoilaExecutor.show_tracebacks`, but there will be other code paths in the future that will also need to react to this (more on this later). So I think a better place for configuration is `VoilaConfiguration`.