### PR TITLE
WIP feat: progressively load the widgets while the kernel is executing

### DIFF
--- a/share/jupyter/voila/templates/lab/index.html.j2
+++ b/share/jupyter/voila/templates/lab/index.html.j2
@@ -60,6 +60,8 @@ var voila_heartbeat = function() {
         "kernelId": "{{kernel_id}}"
     }
     </script>
+    {{ voila_setup(resources.base_url, resources.nbextensions) }}
+
     {% set cell_count = nb.cells|length %}
     {#
     Voilà is using Jinja's Template.generate method to not render the whole template in one go.
@@ -95,5 +97,4 @@ var voila_heartbeat = function() {
 {%- endblock body_footer -%}
 
 {% block footer_js %}
-{{ voila_setup(resources.base_url, resources.nbextensions) }}
 {% endblock footer_js %}


### PR DESCRIPTION
This will connect to the kernel as soon as possible, and tries to create
widget during execution. This avoids having to get all the widgets after
execution, and is an alterative to:
https://github.com/voila-dashboards/voila/pull/766

Issues:
 * since the whole jupyter message handling is 'synchronous' it awaits
   at a top level and goes all the way down, get_model needs to be resolved
   without any new message coming from the kernel.
 * Despite making handle_comm_open not returning a promise, we still get
   a stalling of the whole message q.

Despite these issues, the loading time is significantly reduced, since
the page renders almost instantly when it succeeds (e.g. when no widgets
are missed).