### PR TITLE
chore: show a user friendly error msg when an error occurs

### DIFF
--- a/share/jupyter/voila/templates/lab/index.html.j2
+++ b/share/jupyter/voila/templates/lab/index.html.j2
@@ -32,6 +32,12 @@
 {% block jupyter_widgets %}
 {% endblock jupyter_widgets %}
 
+{% block error -%}
+<div>An unexpected error occurred while executing...</div>
+{{ super() }}
+{%- endblock error %}
+
+
 {%- block body_header -%}
 {% if resources.theme == 'dark' %}
 <body class="jp-Notebook theme-dark" data-base-url="{{resources.base_url}}voila/">


### PR DESCRIPTION
I'm not sure if we'd like to explain a bit more besides showing the error, especially when the stacktrace is shown it is a but 'crude' to users.

In any case, this is an example for @aschlaep on how one can add some custom error msg to a template.