### PR TITLE
Fix stray tag in the lab template

### DIFF
--- a/share/jupyter/voila/templates/lab/index.html.j2
+++ b/share/jupyter/voila/templates/lab/index.html.j2
@@ -91,9 +91,6 @@ var voila_heartbeat = function() {
     el.style.display = 'unset'
   })();
 </script>
+{{ voila_setup(resources.base_url, resources.nbextensions) }}
 {{ super() }}
 {%- endblock body_footer -%}
-
-{% block footer_js %}
-{{ voila_setup(resources.base_url, resources.nbextensions) }}
-{% endblock footer_js %}


### PR DESCRIPTION
Noticed with the `voila-gridstack` template which is using `lab` as the base template: https://github.com/voila-dashboards/voila-gridstack/blob/23d747087aaff5007769074b7ac780c59595a71b/share/jupyter/nbconvert/templates/gridstack/conf.json#L1

![image](https://user-images.githubusercontent.com/591645/100855741-d181ad80-348a-11eb-87a8-3738317fc6d0.png)

Moving the `voila_setup` above to the `body_footer` block should place the script before the `</body>` closing tag:

![image](https://user-images.githubusercontent.com/591645/100855847-f2e29980-348a-11eb-8bff-10e4a3eeb5df.png)
