### PR TITLE
Unpin jupyter_server in the tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,8 +99,6 @@ setup_args = dict(
         "test": [
             "ipywidgets",
             "mock",
-            # TODO: unpin
-            "jupyter_server~=1.0.1",
             "matplotlib",
             "pytest",
             "pytest-tornasync",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,11 @@ BASE_DIR = os.path.dirname(__file__)
 
 
 @pytest.fixture
+def base_url():
+    return "/"
+
+
+@pytest.fixture
 def notebook_directory():
     return os.path.join(BASE_DIR, 'notebooks')
 


### PR DESCRIPTION
Unpin the `jupyter_server` dependency in the `test` `extras_require`, and define a `base_url` fixture instead.

Similar to https://github.com/voila-dashboards/voila-gridstack/pull/74