### PR TITLE
Fix typo in #797

### DIFF
--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -336,6 +336,6 @@ By default, Voilà does not have an execution timeout, meaning there is no limit
 
 .. code-block:: bash
 
-    voila ---VoilaExecutor.timeout=30 your_notebook.ipynb
+    voila --VoilaExecutor.timeout=30 your_notebook.ipynb
 
 With this setting, if any cell takes longer than 30 seconds to run, a ``TimeoutError`` will be raised.  You can further customize this behavior using the ``VoilaExecutor.timeout_func`` and ``VoilaExecutor.interrupt_on_timeout`` options.


### PR DESCRIPTION
Oops, sorry @jtpio, just noticed I had a triple `---` instead of double `--` in #797... here's a quick fix.  Sorry about that, not sure how I missed it.