### PR TITLE
[Doc] Fix Voilà endpoint in Binder config

### DIFF
--- a/docs/source/deploy.rst
+++ b/docs/source/deploy.rst
@@ -66,7 +66,7 @@ being used for reproducible research, making it an excellent fit for deploying V
 
 3. Go to `mybinder.org <https://mybinder.org>`__ and enter the URL of the repository.
 
-4. In ``Path to a notebook file``, select ``URL`` and use the Voilà endpoint: ``/voila/render/path/to/notebook.ipynb``
+4. In ``Path to a notebook file``, select ``URL`` and use the Voilà endpoint: ``voila/render/path/to/notebook.ipynb``
 
 5. Click ``Launch``.
 


### PR DESCRIPTION
Fixes #776

As presented in #776, the Voilà endpoint (when using Voilà in Binder) can fail with a leading slash.
I simply propose to make the no-leading-slash version the proposed one in the official documentation.

_It isn't much, but I spent a couple minutes figuring it out.. so I hope this will save some time to other people in the future._