### PR TITLE
fix: do not output widget state in html

### DIFF
--- a/share/jupyter/voila/templates/classic/index.html.j2
+++ b/share/jupyter/voila/templates/classic/index.html.j2
@@ -49,7 +49,9 @@
     <div class="container" id="notebook-container">
 {% endblock body_header %}
 
+{%- block footer %}
 {% block footer_js %}
 {{ voila_setup(resources.base_url, resources.nbextensions) }}
 {% endblock footer_js %}
-
+</html>
+{%- endblock footer-%}

--- a/share/jupyter/voila/templates/lab/index.html.j2
+++ b/share/jupyter/voila/templates/lab/index.html.j2
@@ -94,3 +94,9 @@ var voila_heartbeat = function() {
 {{ voila_setup(resources.base_url, resources.nbextensions) }}
 {{ super() }}
 {%- endblock body_footer -%}
+
+{%- block footer %}
+{% block footer_js %}
+{% endblock footer_js %}
+</html>
+{%- endblock footer-%}


### PR DESCRIPTION
cc @minrk

The noise observed at the output of https://gke.mybinder.org/v2/gh/minrk/covid19-norway/HEAD?urlpath=%2Fvoila%2Frender%2Fcorona-data.ipynb is caused by a `</script>` tag included in the widget state, which is wrapped by `<script> ... </script>` causing an early closing of that script tag.

This is an issue/bug for nbconvert, but for voila, we should not even see this widget state, since we sync it over the websocket.

One strange thing with this fix is that I could only reproduce it locally in my dev environment for the classic template, while for the lab template I didn't get the widget output at all. The only way I could reproduce it is to start from the https://github.com/minrk/covid19-norway/blob/main/environment.yml file.
It might be unrelated to this issue/PR, but I don't want to forget this quirk, since I don't understand it (which usually means there is another bug somewhere).