### PR TITLE
Add job to automate releases

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -101,3 +101,74 @@ jobs:
           jupyter nbextension list 2>&1 | grep -ie "voila/extension.*enabled" -
           voila --version
           voila --help
+
+  release:
+    # TODO
+    # if: startsWith(github.ref, 'refs/tags/')
+    needs: [install]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: actions/download-artifact@v2
+      with:
+        name: dist ${{ github.run_number }}
+        path: ./tmp
+    - name: Copy to ./dist
+      run: |
+        mkdir dist/
+        cp ./tmp/voila*.tar.gz ./tmp/voila*.whl dist
+        ls dist
+    - name: Publish a Python distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        # TODO: switch to prod
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+        skip_existing: true
+    - uses: actions/setup-node@v2
+      with:
+       node-version: '14.x'
+       registry-url: 'https://registry.npmjs.org'
+    - name: Publish to npm
+      env:
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: |
+        npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+        cd packages/jupyterlab-preview
+        npm publish
+    - name: Get the current tag
+      id: current_tag
+      run: |
+        tag=`git describe --abbrev=0 --tags $(git rev-list --tags --max-count=1)`
+        echo "::set-output name=tag::${tag}"
+    - name: Get the previous tag
+      id: previous_tag
+      run: |
+        tag=`git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1)`
+        echo "::set-output name=tag::${tag}"
+    - name: Generate Changelog
+      env:
+        CHANGELOG_GITHUB_TOKEN: ${{ secrets.CHANGELOG_GITHUB_TOKEN }}
+      run: |
+        docker run --rm -v "$(pwd)":/usr/local/src/your-app \
+          -e CHANGELOG_GITHUB_TOKEN=${CHANGELOG_GITHUB_TOKEN} \
+          ferrarimarco/github-changelog-generator \
+          github_changelog_generator -u voila-dashboards -p voila --usernames-as-github-logins --no-issues --no-unreleased \
+          --since-tag ${{ steps.previous_tag.outputs.tag }} --header "" --pr-label "## Changes"
+        head -n -1 CHANGELOG.md > CHANGELOG
+    # - name: Create Release
+    #   id: create_release
+    #   uses: actions/create-release@v1
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #   with:
+    #     tag_name: ${{ github.ref }}
+    #     release_name: ${{ github.ref }}
+    #     body_path: CHANGELOG
+    #     # TODO: set to false?
+    #     draft: true
+    #     prerelease: false
+

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,35 @@
 # Making a new release of Voilà
 
-## Getting a clean environment
+## Automated releases
+
+Releases are automated using GitHub Actions. They are triggered when a new tag is pushed to the remote.
+
+To cut a new release, run the following:
+
+```bash
+# checkout the master branch
+git checkout master
+
+# bump the version
+# 1. update `voila/_version.py`
+# 2. update `environment.yml`
+
+# commit and push
+git add voila/_version.py environment.yml
+git commit -m "Release x.y.z"
+git tag x.y.z
+git checkout stable
+git reset --hard master
+git push origin master stable x.y.z
+```
+
+The release workflow also creates a GitHub release with the new changes generated with [github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator).
+
+If you would still like to do the release manually instead, read below.
+
+## Manual Releases
+
+### Getting a clean environment
 
 Creating a new environment can help avoid pushing local changes and any extra tag.
 
@@ -15,7 +44,7 @@ Alternatively, the local repository can be cleaned with:
 git clean -fdx
 ```
 
-## Releasing on PyPI
+### Releasing on PyPI
 
 Make sure the `dist/` folder is empty.
 
@@ -29,7 +58,7 @@ Make sure the `dist/` folder is empty.
 7. `export TWINE_USERNAME=mypypi_username`
 8. `twine upload dist/*`
 
-## Releasing on conda-forge
+### Releasing on conda-forge
 
 1. Open a new PR on https://github.com/conda-forge/voila-feedstock to update the `version` and the `sha256` hash (see [example](https://github.com/conda-forge/voila-feedstock/pull/23/files))
 2. Wait for the tests
@@ -37,7 +66,7 @@ Make sure the `dist/` folder is empty.
 
 The new version will be available on `conda-forge` soon after.
 
-## Committing and tagging
+### Committing and tagging
 
 Commit the changes, create a new release tag, and update the `stable` branch (for Binder), where `x.y.z` denotes the new version:
 
@@ -51,7 +80,7 @@ git reset --hard master
 git push origin master stable x.y.z
 ```
 
-# Making a new release of @voila-dashboards/jupyterlab-preview
+### Making a new release of @voila-dashboards/jupyterlab-preview
 
 The prebuilt extension is already packaged in the main Python package.
 
@@ -60,13 +89,13 @@ However we also publish it to `npm` to:
 - let other third-party extensions depend on `@voila-dashboards/jupyterlab-preview`
 - let users install from source if they would like to
 
-## Releasing on npm
+### Releasing on npm
 
 1. Update [packages/jupyterlab-preview/package.json](./packages/jupyterlab-preview/package.json) with the new version number (to be done when making a new release of the Python package)
 2. `cd ./packages/jupyterlab-preview`
 3. `npm login`
 4. `npm publish`
 
-## Committing
+### Committing
 
 The JupyterLab extension should follow the publish cycle of the main Python package (see above).


### PR DESCRIPTION
Fixes #805 

Add a new job to the existing `packaging` workflow, to automate releases to `PyPI` and `npm`.

### TODO

- [x] Update `RELEASE.md` to mention releases are automated
- [x] Generate the changelog using [github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator)
- [ ] Create the GitHub release automatically when everything is published
- [ ] Trigger on new tags only
- [ ] Switch to the prod `PyPI`
- [ ] Add auth tokens as GitHub secrets 
- [ ] Move the release job to its own workflow? (it's a bit tricky at the moment to share jobs and logic between github actions workflows)
