### PR TITLE
Switch to jsdeliver for the CDN

### DIFF
--- a/packages/voila/src/loader.ts
+++ b/packages/voila/src/loader.ts
@@ -7,7 +7,7 @@
  * The full license is in the file LICENSE, distributed with this software. *
  ****************************************************************************/
 
-const cdn = 'https://unpkg.com/';
+const cdn = 'https://cdn.jsdelivr.net/npm/';
 
 /**
  * Load a package using requirejs and return a promise
@@ -50,7 +50,7 @@ function moduleNameToCDNUrl(moduleName: string, moduleVersion: string) {
  * @param moduleName The name of the module to load..
  * @param version The semver range for the module, if loaded from a CDN.
  *
- * By default, the CDN service used is unpkg.com. However, this default can be
+ * By default, the CDN service used is cdn.jsdelivr.net. However, this default can be
  * overriden by specifying another URL via the HTML attribute
  * "data-jupyter-widgets-cdn" on a script tag of the page.
  *

--- a/share/jupyter/voila/templates/base/page.html
+++ b/share/jupyter/voila/templates/base/page.html
@@ -13,7 +13,7 @@
     {% block stylesheets %}
     {% endblock %}
 
-    <link rel="stylesheet" href="https://unpkg.com/font-awesome@4.5.0/css/font-awesome.min.css" type="text/css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/font-awesome@4.5.0/css/font-awesome.min.css" type="text/css" />
 
     {% block meta %}
     {% endblock %}

--- a/share/jupyter/voila/templates/classic/index.html.j2
+++ b/share/jupyter/voila/templates/classic/index.html.j2
@@ -39,7 +39,7 @@
       display: none;
     }
   </style>
-<link rel="stylesheet" href="https://unpkg.com/font-awesome@4.5.0/css/font-awesome.min.css" type="text/css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/font-awesome@4.5.0/css/font-awesome.min.css" type="text/css" />
 {{ super() }}
 {%- endblock html_head_css -%}
 

--- a/share/jupyter/voila/templates/lab/index.html.j2
+++ b/share/jupyter/voila/templates/lab/index.html.j2
@@ -17,7 +17,7 @@
 {%- endblock html_head_js -%}
 
 {%- block html_head_css -%}
-<link rel="stylesheet" href="https://unpkg.com/font-awesome@4.5.0/css/font-awesome.min.css" type="text/css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/font-awesome@4.5.0/css/font-awesome.min.css" type="text/css" />
 {{ super() }}
 {{ spinner.css() }}
   <style>


### PR DESCRIPTION
Switch to jsdeliver for the CDN, similar to the recent PR in `ipywidgets`: https://github.com/jupyter-widgets/ipywidgets/pull/3121

cc @davidbrochart if you would like to review
