### PR TITLE
Sort notebooks within a folder alphabetically

### DIFF
--- a/voila/treehandler.py
+++ b/voila/treehandler.py
@@ -64,7 +64,7 @@ class VoilaTreeHandler(JupyterHandler):
                 __, ext = os.path.splitext(content.get('path'))
                 return ext in self.allowed_extensions
 
-            contents['content'] = sorted(contents['content'], key = lambda i: i['name'])
+            contents['content'] = sorted(contents['content'], key=lambda i: i['name'])
             contents['content'] = filter(allowed_content, contents['content'])
             self.write(self.render_template('tree.html',
                        page_title=page_title,

--- a/voila/treehandler.py
+++ b/voila/treehandler.py
@@ -64,6 +64,7 @@ class VoilaTreeHandler(JupyterHandler):
                 __, ext = os.path.splitext(content.get('path'))
                 return ext in self.allowed_extensions
 
+            contents['content'] = sorted(contents['content'], key = lambda i: i['name'])
             contents['content'] = filter(allowed_content, contents['content'])
             self.write(self.render_template('tree.html',
                        page_title=page_title,


### PR DESCRIPTION
Rebased version of  #791 by @giswqs  

Fixes https://github.com/voila-dashboards/voila/issues/757

Line added: 
`contents['content'] = sorted(contents['content'], key = lambda i: i['name'])`

Before:
![](https://i.imgur.com/8f4a4LK.png)


After:
![](https://i.imgur.com/8SbVFAZ.png)

