### PR TITLE
add allow-downloads to iframe sandbox attribute

### DIFF
--- a/packages/jupyterlab-preview/src/preview.tsx
+++ b/packages/jupyterlab-preview/src/preview.tsx
@@ -44,7 +44,9 @@ export class VoilaPreview extends DocumentWidget<IFrame, INotebookModel> {
   constructor(options: VoilaPreview.IOptions) {
     super({
       ...options,
-      content: new IFrame({ sandbox: ['allow-same-origin', 'allow-scripts'] })
+      content: new IFrame({
+        sandbox: ['allow-same-origin', 'allow-scripts', 'allow-downloads']
+      })
     });
 
     window.onmessage = (event: any) => {


### PR DESCRIPTION
allows users to download files with voila preview in jupyter lab

This is an cleanup of #744 