### PR TITLE
feat: make the multi kernel manager configurable

### DIFF
--- a/voila/app.py
+++ b/voila/app.py
@@ -38,7 +38,6 @@ from traitlets.config.application import Application
 from traitlets.config.loader import Config
 from traitlets import Unicode, Integer, Bool, Dict, List, default
 
-from jupyter_server.services.kernels.kernelmanager import AsyncMappingKernelManager
 from jupyter_server.services.kernels.handlers import KernelHandler, ZMQChannelsHandler
 from jupyter_server.services.contents.largefilemanager import LargeFileManager
 from jupyter_server.base.handlers import FileFindHandler, path_regex
@@ -409,7 +408,7 @@ class Voila(Application):
             parent=self
         )
 
-        self.kernel_manager = AsyncMappingKernelManager(
+        self.kernel_manager = self.voila_configuration.multi_kernel_manager_class(
             parent=self,
             connection_dir=self.connection_dir,
             kernel_spec_manager=self.kernel_spec_manager,

--- a/voila/configuration.py
+++ b/voila/configuration.py
@@ -8,7 +8,7 @@
 #############################################################################
 
 import traitlets.config
-from traitlets import Unicode, Bool, Dict, List, Int, Enum
+from traitlets import Unicode, Bool, Dict, List, Int, Enum, Type
 
 
 class VoilaConfiguration(traitlets.config.Configurable):
@@ -85,3 +85,11 @@ class VoilaConfiguration(traitlets.config.Configurable):
     show_tracebacks = Bool(False, config=True, help=(
         'Whether to send tracebacks to clients on exceptions.'
     ))
+
+    multi_kernel_manager_class = Type(
+        default_value='jupyter_server.services.kernels.kernelmanager.AsyncMappingKernelManager',
+        klass='jupyter_client.multikernelmanager.MultiKernelManager',
+        help="""The kernel manager class. This is useful to specify a different kernel manager,
+        for example a kernel manager with support for pooling.
+        """
+    ).tag(config=True)


### PR DESCRIPTION
This replaces #820 so that the multi kernel manager can evolve separately from voila.
Example configuration (voila.json):
```json
{
    "VoilaConfiguration": {
        "multi_kernel_manager_class": "hotpot_km.pool.PoolMappingKernelManager"
    },
    "PoolMappingKernelManager": {
        "pool_size_default": 3
    }
}
```

The kernel manager of #820 will go into https://github.com/voila-dashboards/hotpot_km (TODO)

cc @vidartf  @havok2063