### PR TITLE
Fix config tag deprecated

### DIFF
--- a/voila/configuration.py
+++ b/voila/configuration.py
@@ -15,10 +15,10 @@ class VoilaConfiguration(traitlets.config.Configurable):
     """Common configuration options between the server extension and the application."""
     allow_template_override = Enum(['YES', 'NOTEBOOK', 'NO'], 'YES', help='''
     Allow overriding the template (YES), or not (NO), or only from the notebook metadata.
-    ''').tag(config=True)
+    ''', config=True)
     allow_theme_override = Enum(['YES', 'NOTEBOOK', 'NO'], 'YES', help='''
     Allow overriding the theme (YES), or not (NO), or only from the notebook metadata.
-    ''').tag(config=True)
+    ''', config=True)
     template = Unicode(
         'lab',
         config=True,
@@ -29,29 +29,32 @@ class VoilaConfiguration(traitlets.config.Configurable):
     )
     resources = Dict(
         allow_none=True,
+        config=True,
         help="""
         extra resources used by templates;
         example use with --template=reveal
         --VoilaConfiguration.resources="{'reveal': {'transition': 'fade', 'scroll': True}}"
         """
-    ).tag(config=True)
-    theme = Unicode('light').tag(config=True)
-    strip_sources = Bool(True, help='Strip sources from rendered html').tag(config=True)
+    )
+    theme = Unicode('light', config=True)
+    strip_sources = Bool(True, config=True, help='Strip sources from rendered html')
     enable_nbextensions = Bool(False, config=True, help=('Set to True for Voilà to load notebook extensions'))
 
     file_whitelist = List(
         Unicode(),
         [r'.*\.(png|jpg|gif|svg)'],
+        config=True,
         help=r"""
     List of regular expressions for controlling which static files are served.
     All files that are served should at least match 1 whitelist rule, and no blacklist rule
     Example: --VoilaConfiguration.file_whitelist="['.*\.(png|jpg|gif|svg)', 'public.*']"
     """,
-    ).tag(config=True)
+    )
 
     file_blacklist = List(
         Unicode(),
         [r'.*\.(ipynb|py)'],
+        config=True,
         help=r"""
     List of regular expressions for controlling which static files are forbidden to be served.
     All files that are served should at least match 1 whitelist rule, and no blacklist rule
@@ -59,37 +62,40 @@ class VoilaConfiguration(traitlets.config.Configurable):
     --VoilaConfiguration.file_whitelist="['.*']" # all files
     --VoilaConfiguration.file_blacklist="['private.*', '.*\.(ipynb)']" # except files in the private dir and notebook files
     """
-    ).tag(config=True)
+    )
 
     language_kernel_mapping = Dict(
         {},
+        config=True,
         help="""Mapping of language name to kernel name
         Example mapping python to use xeus-python, and C++11 to use xeus-cling:
         --VoilaConfiguration.extension_language_mapping='{"python": "xpython", "C++11": "xcpp11"}'
         """,
-    ).tag(config=True)
+    )
 
     extension_language_mapping = Dict(
         {},
+        config=True,
         help='''Mapping of file extension to kernel language
         Example mapping .py files to a python language kernel, and .cpp to a C++11 language kernel:
         --VoilaConfiguration.extension_language_mapping='{".py": "python", ".cpp": "C++11"}'
         ''',
-    ).tag(config=True)
+    )
 
-    http_keep_alive_timeout = Int(10, help="""
+    http_keep_alive_timeout = Int(10, config=True, help="""
     When a cell takes a long time to execute, the http connection can timeout (possibly because of a proxy).
     Voila sends a 'heartbeat' message after the timeout is passed to keep the http connection alive.
-    """).tag(config=True)
+    """)
 
     show_tracebacks = Bool(False, config=True, help=(
         'Whether to send tracebacks to clients on exceptions.'
     ))
 
     multi_kernel_manager_class = Type(
+        config=True,
         default_value='jupyter_server.services.kernels.kernelmanager.AsyncMappingKernelManager',
         klass='jupyter_client.multikernelmanager.MultiKernelManager',
         help="""The kernel manager class. This is useful to specify a different kernel manager,
         for example a kernel manager with support for pooling.
         """
-    ).tag(config=True)
+    )


### PR DESCRIPTION
Follow up of #841, where @vidartf noted that we use the deprecated `.tag(config=True)`