### PR TITLE
Backport PR #854 on branch 0.1.x (Fall back to language_info name when searching for kernel)

### DIFF
--- a/tests/app/no_metadata.py
+++ b/tests/app/no_metadata.py
@@ -1,0 +1,17 @@
+import pytest
+
+
+@pytest.fixture
+def non_existing_notebook_metadata(base_url):
+    return base_url + "voila/render/no_metadata.ipynb"
+
+
+@pytest.fixture
+def voila_args(notebook_directory, voila_args_extra):
+    return ['--VoilaTest.root_dir=%r' % notebook_directory] + voila_args_extra
+
+
+async def test_non_existing_metadata(http_server_client, non_existing_notebook_metadata):
+    response = await http_server_client.fetch(non_existing_notebook_metadata)
+    assert response.code == 200
+    assert 'Executing without notebook metadata' in response.body.decode('utf-8')

--- a/tests/notebooks/no_metadata.ipynb
+++ b/tests/notebooks/no_metadata.ipynb
@@ -1,0 +1,17 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Executing without notebook metadata')"
+   ]
+  }
+ ],
+ "metadata": {
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -183,7 +183,8 @@ class VoilaHandler(JupyterHandler):
         # Find a spec matching the language if the kernel name does not exist in the kernelspecs
         if kernel_name not in all_kernel_specs:
             missing_kernel_name = kernel_name
-            kernel_name = await self.find_kernel_name_for_language(kernelspec.language.lower(), kernel_specs=all_kernel_specs)
+            language = kernelspec.get('language', notebook.metadata.get('language_info', {}).get('name', ''))
+            kernel_name = await self.find_kernel_name_for_language(language.lower(), kernel_specs=all_kernel_specs)
             self.log.warning('Could not find a kernel named %r, will use  %r', missing_kernel_name, kernel_name)
         # We make sure the notebook's kernelspec is correct
         notebook.metadata.kernelspec.name = kernel_name


### PR DESCRIPTION
Backport PR #854:  Fall back to language_info name when searching for kernel