### PR TITLE
Run CI on all branches for push events

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build Frontend Packages
 on:
   push:
     branches:
-    - master
+    - '*'
   pull_request:
     branches:
     - '*'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Tests
 on:
   push:
     branches:
-    - master
+    - '*'
   pull_request:
     branches:
     - '*'

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -2,9 +2,11 @@ name: Packaging
 
 on:
   push:
-    branches: [ master ]
+    branches:
+    - '*'
   pull_request:
-    branches: '*'
+    branches:
+    - '*'
 
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: 1


### PR DESCRIPTION
So it also runs when pushing to other branches like `0.1.x`.

Use `*` for all branches to avoid having to maintain an explicit list of branches.