### PR TITLE
fix: baseurl not used when requesting kernel model

### DIFF
--- a/packages/voila/src/kernel.ts
+++ b/packages/voila/src/kernel.ts
@@ -21,7 +21,7 @@ export async function connectKernel(
   kernelId = kernelId ?? PageConfig.getOption('kernelId');
   const serverSettings = ServerConnection.makeSettings({ baseUrl });
 
-  const model = await KernelAPI.getKernelModel(kernelId);
+  const model = await KernelAPI.getKernelModel(kernelId, serverSettings);
   if (!model) {
     return;
   }


### PR DESCRIPTION
Changed in commit f9a5d2adf4a7453285aea30e152bc2b5fff6f257 of PR #840