### PR TITLE
Support async content manager

### DIFF
--- a/voila/handler.py
+++ b/voila/handler.py
@@ -242,7 +242,7 @@ class VoilaHandler(JupyterHandler):
                 yield output_cell
 
     async def load_notebook(self, path):
-        model = self.contents_manager.get(path=path)
+        model = await ensure_async(self.contents_manager.get(path=path))
         if 'content' not in model:
             raise tornado.web.HTTPError(404, 'file not found')
         __, extension = os.path.splitext(model.get('path', ''))


### PR DESCRIPTION
Support async content_manager such as AsyncLargeFileManager to prevent jupyter stucking on listing folders:
https://jupyter-server.readthedocs.io/en/latest/developers/contents.html#asynchronous-support