### PR TITLE
Monkey patch shutdown_kernel

### DIFF
--- a/voila/handler.py
+++ b/voila/handler.py
@@ -172,6 +172,18 @@ class VoilaHandler(JupyterHandler):
 
         self.executor = VoilaExecutor(nb, km=km, config=self.traitlet_config,
                                       show_tracebacks=self.voila_configuration.show_tracebacks)
+        
+        # Get a reference to the original shutdown_kernel method
+        orig_shutdown_kernel = km.shutdown_kernel
+
+        # Define a new shutdown_kernel function that stops client channels, in addition to invoking the old method
+        async def shutdown_kernel(self, *args, executor=self.executor, **kwargs):
+            executor.kc.stop_channels()
+            await orig_shutdown_kernel(*args, **kwargs)
+
+        # Monkey patch the new method
+        from jupyter_client import AsyncKernelManager
+        km.shutdown_kernel = shutdown_kernel.__get__(km, AsyncKernelManager)
 
         ###
         # start kernel client


### PR DESCRIPTION
This monkey patches the `shutdown_kernel` method so that client channel connections are also shutdown, resolving a memory leak.