### PR TITLE
Add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,942 @@
+# Changelog
+
+<!-- <START NEW CHANGELOG ENTRY> -->
+
+## 0.2.10
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.2.9...0.2.10))
+
+### Documentation improvements
+
+- update link to config options of Jupyter Server [#874](https://github.com/voila-dashboards/voila/pull/874) ([@sir-sigurd](https://github.com/sir-sigurd))
+
+### Other merged PRs
+
+- fix: baseurl not used when requesting kernel model [#876](https://github.com/voila-dashboards/voila/pull/876) ([@mariobuikhuizen](https://github.com/mariobuikhuizen))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2021-04-13&to=2021-04-28&type=c))
+
+[@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2021-04-13..2021-04-28&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2021-04-13..2021-04-28&type=Issues) | [@mariobuikhuizen](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amariobuikhuizen+updated%3A2021-04-13..2021-04-28&type=Issues) | [@sir-sigurd](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Asir-sigurd+updated%3A2021-04-13..2021-04-28&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
+## 0.2.9
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.2.8...0.2.9))
+
+### Merged PRs
+
+- Update to font awesome 5 [#870](https://github.com/voila-dashboards/voila/pull/870) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2021-04-12&to=2021-04-13&type=c))
+
+[@jasongrout](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajasongrout+updated%3A2021-04-12..2021-04-13&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2021-04-12..2021-04-13&type=Issues)
+
+## 0.2.8
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.2.7...0.2.8))
+
+### Merged PRs
+
+- typo in error message [#867](https://github.com/voila-dashboards/voila/pull/867) ([@jembishop](https://github.com/jembishop))
+- Run CI on all branches for push events [#862](https://github.com/voila-dashboards/voila/pull/862) ([@jtpio](https://github.com/jtpio))
+- Wrap get_kernel with possible async handler [#859](https://github.com/voila-dashboards/voila/pull/859) ([@declanvk](https://github.com/declanvk))
+- Trigger GitHub Actions on all branches for PRs [#856](https://github.com/voila-dashboards/voila/pull/856) ([@jtpio](https://github.com/jtpio))
+- Fall back to language_info name when searching for kernel [#854](https://github.com/voila-dashboards/voila/pull/854) ([@jtpio](https://github.com/jtpio))
+- Fix config tag deprecated [#847](https://github.com/voila-dashboards/voila/pull/847) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Add kernel death test [#845](https://github.com/voila-dashboards/voila/pull/845) ([@davidbrochart](https://github.com/davidbrochart))
+- feat: make the multi kernel manager configurable [#841](https://github.com/voila-dashboards/voila/pull/841) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Update to newer packages for the voila frontend [#840](https://github.com/voila-dashboards/voila/pull/840) ([@jtpio](https://github.com/jtpio))
+- Remove tests/configs/general/migrated [#839](https://github.com/voila-dashboards/voila/pull/839) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2021-02-19&to=2021-04-12&type=c))
+
+[@agoose77](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aagoose77+updated%3A2021-02-19..2021-04-12&type=Issues) | [@bollwyvl](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Abollwyvl+updated%3A2021-02-19..2021-04-12&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Adavidbrochart+updated%3A2021-02-19..2021-04-12&type=Issues) | [@declanvk](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Adeclanvk+updated%3A2021-02-19..2021-04-12&type=Issues) | [@enricogandini](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aenricogandini+updated%3A2021-02-19..2021-04-12&type=Issues) | [@havok2063](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ahavok2063+updated%3A2021-02-19..2021-04-12&type=Issues) | [@jembishop](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajembishop+updated%3A2021-02-19..2021-04-12&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2021-02-19..2021-04-12&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2021-02-19..2021-04-12&type=Issues) | [@marckassay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amarckassay+updated%3A2021-02-19..2021-04-12&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AmartinRenou+updated%3A2021-02-19..2021-04-12&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2021-02-19..2021-04-12&type=Issues)
+
+## 0.2.7
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.2.6...0.2.7))
+
+### Merged PRs
+
+- add allow-downloads to iframe sandbox attribute [#834](https://github.com/voila-dashboards/voila/pull/834) ([@jamesjnadeau](https://github.com/jamesjnadeau))
+- Update release instructions [#832](https://github.com/voila-dashboards/voila/pull/832) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Sort notebooks within a folder alphabetically [#831](https://github.com/voila-dashboards/voila/pull/831) ([@jtpio](https://github.com/jtpio))
+- Switch to jsdeliver for the CDN [#830](https://github.com/voila-dashboards/voila/pull/830) ([@jtpio](https://github.com/jtpio))
+- Log information about classic extension loading [#822](https://github.com/voila-dashboards/voila/pull/822) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Add TypeScript and tsconfig.json [#818](https://github.com/voila-dashboards/voila/pull/818) ([@jtpio](https://github.com/jtpio))
+- Unpin xtl=0.6.23 in the tests [#815](https://github.com/voila-dashboards/voila/pull/815) ([@jtpio](https://github.com/jtpio))
+- Adopt monorepo structure [#808](https://github.com/voila-dashboards/voila/pull/808) ([@jtpio](https://github.com/jtpio))
+- feat: allow showing of stacktraces in server extension mode [#758](https://github.com/voila-dashboards/voila/pull/758) ([@maartenbreddels](https://github.com/maartenbreddels))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2021-01-11&to=2021-02-19&type=c))
+
+[@dependabot](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Adependabot+updated%3A2021-01-11..2021-02-19&type=Issues) | [@GregSilverman](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AGregSilverman+updated%3A2021-01-11..2021-02-19&type=Issues) | [@havok2063](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ahavok2063+updated%3A2021-01-11..2021-02-19&type=Issues) | [@jamesjnadeau](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajamesjnadeau+updated%3A2021-01-11..2021-02-19&type=Issues) | [@JohanMabille](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AJohanMabille+updated%3A2021-01-11..2021-02-19&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2021-01-11..2021-02-19&type=Issues) | [@juliechoong](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajuliechoong+updated%3A2021-01-11..2021-02-19&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2021-01-11..2021-02-19&type=Issues) | [@rg98](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Arg98+updated%3A2021-01-11..2021-02-19&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2021-01-11..2021-02-19&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Avidartf+updated%3A2021-01-11..2021-02-19&type=Issues)
+
+## 0.2.6
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.2.5...0.2.6))
+
+### Merged PRs
+
+- fix: do not output widget state in html [#804](https://github.com/voila-dashboards/voila/pull/804) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Add jupyterlab=3 to the Binder environment [#803](https://github.com/voila-dashboards/voila/pull/803) ([@jtpio](https://github.com/jtpio))
+- Fix stray tag in the lab template [#774](https://github.com/voila-dashboards/voila/pull/774) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2021-01-11&to=2021-01-11&type=c))
+
+[@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2021-01-11..2021-01-11&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2021-01-11..2021-01-11&type=Issues)
+
+## 0.2.5
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.2.4...0.2.5))
+
+### Documentation improvements
+
+- Fix typo in #797 [#799](https://github.com/voila-dashboards/voila/pull/799) ([@jeffyjefflabs](https://github.com/jeffyjefflabs))
+- Describe cell execution timeout in docs [#797](https://github.com/voila-dashboards/voila/pull/797) ([@jeffyjefflabs](https://github.com/jeffyjefflabs))
+- Remove duplicated content for contributing [#788](https://github.com/voila-dashboards/voila/pull/788) ([@jtpio](https://github.com/jtpio))
+
+### Other merged PRs
+
+- Update to JupyterLab 3.0 final [#802](https://github.com/voila-dashboards/voila/pull/802) ([@jtpio](https://github.com/jtpio))
+- [Doc] Fix Voilà endpoint in Binder config [#801](https://github.com/voila-dashboards/voila/pull/801) ([@thomas-bc](https://github.com/thomas-bc))
+- Add CI workflow for packaging [#798](https://github.com/voila-dashboards/voila/pull/798) ([@jtpio](https://github.com/jtpio))
+- Unpin jupyter_server in the tests [#794](https://github.com/voila-dashboards/voila/pull/794) ([@jtpio](https://github.com/jtpio))
+- Test on Python 3.9 [#789](https://github.com/voila-dashboards/voila/pull/789) ([@jtpio](https://github.com/jtpio))
+- Adopt the new distribution system for the JupyterLab extension [#786](https://github.com/voila-dashboards/voila/pull/786) ([@jtpio](https://github.com/jtpio))
+- Remove .travis.yml [#775](https://github.com/voila-dashboards/voila/pull/775) ([@jtpio](https://github.com/jtpio))
+- Fix CI [#767](https://github.com/voila-dashboards/voila/pull/767) ([@martinRenou](https://github.com/martinRenou))
+- fix: log cell execution errors [#753](https://github.com/voila-dashboards/voila/pull/753) ([@mariobuikhuizen](https://github.com/mariobuikhuizen))
+- Move require.min.js script element to be above notebook execution [#735](https://github.com/voila-dashboards/voila/pull/735) ([@jwminton](https://github.com/jwminton))
+- Update the preview extension to JupyterLab 3.0 [#732](https://github.com/voila-dashboards/voila/pull/732) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2020-10-20&to=2021-01-11&type=c))
+
+[@dependabot](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Adependabot+updated%3A2020-10-20..2021-01-11&type=Issues) | [@jeffyjefflabs](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajeffyjefflabs+updated%3A2020-10-20..2021-01-11&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2020-10-20..2021-01-11&type=Issues) | [@jwminton](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajwminton+updated%3A2020-10-20..2021-01-11&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2020-10-20..2021-01-11&type=Issues) | [@mariobuikhuizen](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amariobuikhuizen+updated%3A2020-10-20..2021-01-11&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AmartinRenou+updated%3A2020-10-20..2021-01-11&type=Issues) | [@pelson](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Apelson+updated%3A2020-10-20..2021-01-11&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2020-10-20..2021-01-11&type=Issues) | [@thomas-bc](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Athomas-bc+updated%3A2020-10-20..2021-01-11&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Avidartf+updated%3A2020-10-20..2021-01-11&type=Issues)
+
+## 0.2.4
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.2.3...0.2.4))
+
+### Merged PRs
+
+- fix: classic template did not pass base_url to macro [#741](https://github.com/voila-dashboards/voila/pull/741) ([@maartenbreddels](https://github.com/maartenbreddels))
+- fix: do not fail when a comm msg has no buffers [#731](https://github.com/voila-dashboards/voila/pull/731) ([@maartenbreddels](https://github.com/maartenbreddels))
+- fix: do not fail logging when JS object cannot be cloned [#730](https://github.com/voila-dashboards/voila/pull/730) ([@maartenbreddels](https://github.com/maartenbreddels))
+- fix: when using the back button Voila doesn't load [#719](https://github.com/voila-dashboards/voila/pull/719) ([@mariobuikhuizen](https://github.com/mariobuikhuizen))
+- Don't include map files in distributions [#285](https://github.com/voila-dashboards/voila/pull/285) ([@xhochy](https://github.com/xhochy))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2020-09-23&to=2020-10-20&type=c))
+
+[@afonit](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aafonit+updated%3A2020-09-23..2020-10-20&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2020-09-23..2020-10-20&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2020-09-23..2020-10-20&type=Issues) | [@mariobuikhuizen](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amariobuikhuizen+updated%3A2020-09-23..2020-10-20&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AmartinRenou+updated%3A2020-09-23..2020-10-20&type=Issues) | [@paugier](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Apaugier+updated%3A2020-09-23..2020-10-20&type=Issues) | [@pelson](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Apelson+updated%3A2020-09-23..2020-10-20&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2020-09-23..2020-10-20&type=Issues) | [@TheoMathurin](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ATheoMathurin+updated%3A2020-09-23..2020-10-20&type=Issues) | [@timkpaine](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Atimkpaine+updated%3A2020-09-23..2020-10-20&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Avidartf+updated%3A2020-09-23..2020-10-20&type=Issues) | [@xhochy](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Axhochy+updated%3A2020-09-23..2020-10-20&type=Issues)
+
+## 0.2.3
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.2.2...0.2.3))
+
+### Merged PRs
+
+- Hide cells with no output when inputs are hidden [#718](https://github.com/voila-dashboards/voila/pull/718) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Fixup tornado 6 compat [#716](https://github.com/voila-dashboards/voila/pull/716) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Test with jupyter-server-1 [#715](https://github.com/voila-dashboards/voila/pull/715) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2020-09-17&to=2020-09-23&type=c))
+
+[@agoose77](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aagoose77+updated%3A2020-09-17..2020-09-23&type=Issues) | [@chuckmandu](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Achuckmandu+updated%3A2020-09-17..2020-09-23&type=Issues) | [@joseberlines](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajoseberlines+updated%3A2020-09-17..2020-09-23&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2020-09-17..2020-09-23&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2020-09-17..2020-09-23&type=Issues) | [@timkpaine](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Atimkpaine+updated%3A2020-09-17..2020-09-23&type=Issues)
+
+## 0.2.2
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.2.1...0.2.2))
+
+### Merged PRs
+
+- fix: support DeferredConfigString (hack) [#710](https://github.com/voila-dashboards/voila/pull/710) ([@maartenbreddels](https://github.com/maartenbreddels))
+- fix: allow contents_manager to be a notebook content manager [#709](https://github.com/voila-dashboards/voila/pull/709) ([@maartenbreddels](https://github.com/maartenbreddels))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2020-09-16&to=2020-09-17&type=c))
+
+[@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2020-09-16..2020-09-17&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2020-09-16..2020-09-17&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2020-09-16..2020-09-17&type=Issues)
+
+## 0.2.1
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.2.0b1...0.2.1))
+
+### Merged PRs
+
+- fix: classic templates did not render [#707](https://github.com/voila-dashboards/voila/pull/707) ([@maartenbreddels](https://github.com/maartenbreddels))
+- fix: lab template closed the body tag, super already does this [#706](https://github.com/voila-dashboards/voila/pull/706) ([@maartenbreddels](https://github.com/maartenbreddels))
+- fix: calling include_js led to unclosed script tag [#705](https://github.com/voila-dashboards/voila/pull/705) ([@maartenbreddels](https://github.com/maartenbreddels))
+- chore: update release instructions [#704](https://github.com/voila-dashboards/voila/pull/704) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Chore: update docs for release v0.2 [#703](https://github.com/voila-dashboards/voila/pull/703) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Bump node-fetch from 2.6.0 to 2.6.1 in /packages/jupyterlab-voila [#701](https://github.com/voila-dashboards/voila/pull/701) ([@dependabot](https://github.com/dependabot))
+- Fix installation steps in the doc tests section [#700](https://github.com/voila-dashboards/voila/pull/700) ([@martinRenou](https://github.com/martinRenou))
+- chore(ci): test traitlets 4 and 5 [#699](https://github.com/voila-dashboards/voila/pull/699) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Remove the call to zmq.eventloop.ioloop.install [#697](https://github.com/voila-dashboards/voila/pull/697) ([@jtpio](https://github.com/jtpio))
+- test: preprocessors in conf.json [#695](https://github.com/voila-dashboards/voila/pull/695) ([@maartenbreddels](https://github.com/maartenbreddels))
+- chore(ci): many_iopub_message test still timed out [#686](https://github.com/voila-dashboards/voila/pull/686) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Feature: template and theme override [#637](https://github.com/voila-dashboards/voila/pull/637) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Add show_tracebacks trait [#630](https://github.com/voila-dashboards/voila/pull/630) ([@vidartf](https://github.com/vidartf))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2020-09-10&to=2020-09-16&type=c))
+
+[@dependabot](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Adependabot+updated%3A2020-09-10..2020-09-16&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2020-09-10..2020-09-16&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2020-09-10..2020-09-16&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AmartinRenou+updated%3A2020-09-10..2020-09-16&type=Issues) | [@timkpaine](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Atimkpaine+updated%3A2020-09-10..2020-09-16&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Avidartf+updated%3A2020-09-10..2020-09-16&type=Issues)
+
+## 0.2.0b1
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.2.0b0...0.2.0b1))
+
+### Merged PRs
+
+- Update to nbconvert 6.0 (release) [#698](https://github.com/voila-dashboards/voila/pull/698) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Allow nbclient 0.5 [#696](https://github.com/voila-dashboards/voila/pull/696) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2020-09-08&to=2020-09-10&type=c))
+
+[@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2020-09-08..2020-09-10&type=Issues)
+
+## 0.2.0b0
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.2.0a3...0.2.0b0))
+
+### Merged PRs
+
+- fix: content_manager was not a trait [#691](https://github.com/voila-dashboards/voila/pull/691) ([@maartenbreddels](https://github.com/maartenbreddels))
+- fixup-traitlets-5-breakage [#690](https://github.com/voila-dashboards/voila/pull/690) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- fix: stop executing cells when an error is encountered (replaces #530) [#681](https://github.com/voila-dashboards/voila/pull/681) ([@maartenbreddels](https://github.com/maartenbreddels))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2020-08-19&to=2020-09-08&type=c))
+
+[@afonit](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aafonit+updated%3A2020-08-19..2020-09-08&type=Issues) | [@benlindsay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Abenlindsay+updated%3A2020-08-19..2020-09-08&type=Issues) | [@DougRzz](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ADougRzz+updated%3A2020-08-19..2020-09-08&type=Issues) | [@gbrault](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Agbrault+updated%3A2020-08-19..2020-09-08&type=Issues) | [@jeffyjefflabs](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajeffyjefflabs+updated%3A2020-08-19..2020-09-08&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2020-08-19..2020-09-08&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2020-08-19..2020-09-08&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AmartinRenou+updated%3A2020-08-19..2020-09-08&type=Issues) | [@paugier](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Apaugier+updated%3A2020-08-19..2020-09-08&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2020-08-19..2020-09-08&type=Issues) | [@TheoMathurin](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ATheoMathurin+updated%3A2020-08-19..2020-09-08&type=Issues) | [@timkpaine](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Atimkpaine+updated%3A2020-08-19..2020-09-08&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Avidartf+updated%3A2020-08-19..2020-09-08&type=Issues)
+
+## 0.2.0a3
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.2.0a2...0.2.0a3))
+
+### Merged PRs
+
+- refactor: use macro for voila setup and override jupyter-widget macro [#680](https://github.com/voila-dashboards/voila/pull/680) ([@maartenbreddels](https://github.com/maartenbreddels))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2020-08-18&to=2020-08-19&type=c))
+
+[@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2020-08-18..2020-08-19&type=Issues)
+
+## 0.2.0a2
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.2.0a1...0.2.0a2))
+
+### Merged PRs
+
+- Fixup classic template [#678](https://github.com/voila-dashboards/voila/pull/678) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Add nb argument to kernel_start [#677](https://github.com/voila-dashboards/voila/pull/677) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Voilà with an accent [#676](https://github.com/voila-dashboards/voila/pull/676) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Enable logging in classic template [#673](https://github.com/voila-dashboards/voila/pull/673) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Log js outputs [#671](https://github.com/voila-dashboards/voila/pull/671) ([@hbcarlos](https://github.com/hbcarlos))
+- fix: avoid http (read) timeouts by sending a heartbeat [#668](https://github.com/voila-dashboards/voila/pull/668) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Bump elliptic from 6.4.1 to 6.5.3 in /js [#666](https://github.com/voila-dashboards/voila/pull/666) ([@dependabot](https://github.com/dependabot))
+- Fixup classic template [#662](https://github.com/voila-dashboards/voila/pull/662) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Fix #624 - Broken link in docs [#656](https://github.com/voila-dashboards/voila/pull/656) ([@mourarthur](https://github.com/mourarthur))
+- Add docs for the theme option [#655](https://github.com/voila-dashboards/voila/pull/655) ([@martinRenou](https://github.com/martinRenou))
+- Bump lodash from 4.17.15 to 4.17.19 in /packages/jupyterlab-voila [#653](https://github.com/voila-dashboards/voila/pull/653) ([@dependabot](https://github.com/dependabot))
+- Bump lodash from 4.17.15 to 4.17.19 in /js [#652](https://github.com/voila-dashboards/voila/pull/652) ([@dependabot](https://github.com/dependabot))
+- Remove extra `>` in the customizing docs [#650](https://github.com/voila-dashboards/voila/pull/650) ([@jtpio](https://github.com/jtpio))
+- fix: use template_paths instead of old template_path [#643](https://github.com/voila-dashboards/voila/pull/643) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Remove Voilà CSS preprocessor [#639](https://github.com/voila-dashboards/voila/pull/639) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Spacing and other formatting to docs, avoids build warnings [#636](https://github.com/voila-dashboards/voila/pull/636) ([@danlester](https://github.com/danlester))
+- Update nbclient to stable release [#633](https://github.com/voila-dashboards/voila/pull/633) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Use async_start_new_kernel_client from nbclient [#597](https://github.com/voila-dashboards/voila/pull/597) ([@davidbrochart](https://github.com/davidbrochart))
+- Simplify actions and use mamba [#573](https://github.com/voila-dashboards/voila/pull/573) ([@martinRenou](https://github.com/martinRenou))
+- Document the ability to hide cells based on cell tags [#418](https://github.com/voila-dashboards/voila/pull/418) ([@AartGoossens](https://github.com/AartGoossens))
+- Passing request URI to kernel env [#414](https://github.com/voila-dashboards/voila/pull/414) ([@derek-pyne](https://github.com/derek-pyne))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2020-06-02&to=2020-08-18&type=c))
+
+[@AartGoossens](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AAartGoossens+updated%3A2020-06-02..2020-08-18&type=Issues) | [@afonit](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aafonit+updated%3A2020-06-02..2020-08-18&type=Issues) | [@anxhelahyseni](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aanxhelahyseni+updated%3A2020-06-02..2020-08-18&type=Issues) | [@brichet](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Abrichet+updated%3A2020-06-02..2020-08-18&type=Issues) | [@cantagallo](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Acantagallo+updated%3A2020-06-02..2020-08-18&type=Issues) | [@danlester](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Adanlester+updated%3A2020-06-02..2020-08-18&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Adavidbrochart+updated%3A2020-06-02..2020-08-18&type=Issues) | [@dependabot](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Adependabot+updated%3A2020-06-02..2020-08-18&type=Issues) | [@derek-pyne](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aderek-pyne+updated%3A2020-06-02..2020-08-18&type=Issues) | [@DougRzz](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ADougRzz+updated%3A2020-06-02..2020-08-18&type=Issues) | [@gbrault](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Agbrault+updated%3A2020-06-02..2020-08-18&type=Issues) | [@GregSilverman](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AGregSilverman+updated%3A2020-06-02..2020-08-18&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ahbcarlos+updated%3A2020-06-02..2020-08-18&type=Issues) | [@jakemiller649](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajakemiller649+updated%3A2020-06-02..2020-08-18&type=Issues) | [@jeffyjefflabs](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajeffyjefflabs+updated%3A2020-06-02..2020-08-18&type=Issues) | [@jmurray6](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajmurray6+updated%3A2020-06-02..2020-08-18&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2020-06-02..2020-08-18&type=Issues) | [@kevin-bates](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Akevin-bates+updated%3A2020-06-02..2020-08-18&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Akrassowski+updated%3A2020-06-02..2020-08-18&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2020-06-02..2020-08-18&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AmartinRenou+updated%3A2020-06-02..2020-08-18&type=Issues) | [@mcg1969](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amcg1969+updated%3A2020-06-02..2020-08-18&type=Issues) | [@mgmarino](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amgmarino+updated%3A2020-06-02..2020-08-18&type=Issues) | [@mourarthur](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amourarthur+updated%3A2020-06-02..2020-08-18&type=Issues) | [@prachi-tripathi](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aprachi-tripathi+updated%3A2020-06-02..2020-08-18&type=Issues) | [@stefanmeili](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Astefanmeili+updated%3A2020-06-02..2020-08-18&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2020-06-02..2020-08-18&type=Issues) | [@timkpaine](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Atimkpaine+updated%3A2020-06-02..2020-08-18&type=Issues)
+
+## 0.2.0a1
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.2.0a0...0.2.0a1))
+
+### Merged PRs
+
+- refactor: move output widget to nbclient [#621](https://github.com/voila-dashboards/voila/pull/621) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Update js/package-lock.json [#608](https://github.com/voila-dashboards/voila/pull/608) ([@jtpio](https://github.com/jtpio))
+- Bump acorn from 6.1.1 to 6.4.1 in /js [#558](https://github.com/voila-dashboards/voila/pull/558) ([@dependabot](https://github.com/dependabot))
+- Update links to jupyter-xeus and voila-dashboards orgs [#557](https://github.com/voila-dashboards/voila/pull/557) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2020-05-27&to=2020-06-02&type=c))
+
+[@dependabot](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Adependabot+updated%3A2020-05-27..2020-06-02&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2020-05-27..2020-06-02&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2020-05-27..2020-06-02&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2020-05-27..2020-06-02&type=Issues)
+
+## 0.1.24
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.1.23...0.1.24))
+
+### Merged PRs
+
+- [0.1.x] Run CI on all branches for push events [#863](https://github.com/voila-dashboards/voila/pull/863) ([@jtpio](https://github.com/jtpio))
+- [0.1.x] Trigger GitHub Actions on all branches for PRs [#857](https://github.com/voila-dashboards/voila/pull/857) ([@jtpio](https://github.com/jtpio))
+- Backport PR #854 on branch 0.1.x (Fall back to language_info name when searching for kernel) [#855](https://github.com/voila-dashboards/voila/pull/855) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2020-09-03&to=2021-03-24&type=c))
+
+[@afonit](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aafonit+updated%3A2020-09-03..2021-03-24&type=Issues) | [@agoose77](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aagoose77+updated%3A2020-09-03..2021-03-24&type=Issues) | [@bollwyvl](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Abollwyvl+updated%3A2020-09-03..2021-03-24&type=Issues) | [@chuckmandu](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Achuckmandu+updated%3A2020-09-03..2021-03-24&type=Issues) | [@dependabot](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Adependabot+updated%3A2020-09-03..2021-03-24&type=Issues) | [@gbrault](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Agbrault+updated%3A2020-09-03..2021-03-24&type=Issues) | [@GregSilverman](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AGregSilverman+updated%3A2020-09-03..2021-03-24&type=Issues) | [@havok2063](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ahavok2063+updated%3A2020-09-03..2021-03-24&type=Issues) | [@jeffyjefflabs](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajeffyjefflabs+updated%3A2020-09-03..2021-03-24&type=Issues) | [@JohanMabille](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AJohanMabille+updated%3A2020-09-03..2021-03-24&type=Issues) | [@joseberlines](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajoseberlines+updated%3A2020-09-03..2021-03-24&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2020-09-03..2021-03-24&type=Issues) | [@juliechoong](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajuliechoong+updated%3A2020-09-03..2021-03-24&type=Issues) | [@jwminton](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajwminton+updated%3A2020-09-03..2021-03-24&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2020-09-03..2021-03-24&type=Issues) | [@marckassay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amarckassay+updated%3A2020-09-03..2021-03-24&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AmartinRenou+updated%3A2020-09-03..2021-03-24&type=Issues) | [@paugier](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Apaugier+updated%3A2020-09-03..2021-03-24&type=Issues) | [@pelson](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Apelson+updated%3A2020-09-03..2021-03-24&type=Issues) | [@rg98](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Arg98+updated%3A2020-09-03..2021-03-24&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2020-09-03..2021-03-24&type=Issues) | [@TheoMathurin](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ATheoMathurin+updated%3A2020-09-03..2021-03-24&type=Issues) | [@timkpaine](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Atimkpaine+updated%3A2020-09-03..2021-03-24&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Avidartf+updated%3A2020-09-03..2021-03-24&type=Issues)
+
+## 0.1.23
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.1.22...0.1.23))
+
+### Merged PRs
+
+- fixup-traitlets-5-breakage [#690](https://github.com/voila-dashboards/voila/pull/690) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2020-08-17&to=2020-09-03&type=c))
+
+[@afonit](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aafonit+updated%3A2020-08-17..2020-09-03&type=Issues) | [@benlindsay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Abenlindsay+updated%3A2020-08-17..2020-09-03&type=Issues) | [@cantagallo](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Acantagallo+updated%3A2020-08-17..2020-09-03&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Adavidbrochart+updated%3A2020-08-17..2020-09-03&type=Issues) | [@derek-pyne](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aderek-pyne+updated%3A2020-08-17..2020-09-03&type=Issues) | [@DougRzz](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ADougRzz+updated%3A2020-08-17..2020-09-03&type=Issues) | [@gbrault](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Agbrault+updated%3A2020-08-17..2020-09-03&type=Issues) | [@jeffyjefflabs](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajeffyjefflabs+updated%3A2020-08-17..2020-09-03&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2020-08-17..2020-09-03&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2020-08-17..2020-09-03&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2020-08-17..2020-09-03&type=Issues) | [@timkpaine](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Atimkpaine+updated%3A2020-08-17..2020-09-03&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Avidartf+updated%3A2020-08-17..2020-09-03&type=Issues)
+
+## 0.1.22
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.1.21...0.1.22))
+
+### Merged PRs
+
+- Backport js logging to 0.1.x [#675](https://github.com/voila-dashboards/voila/pull/675) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Back port JS logging to 0.1.x [#674](https://github.com/voila-dashboards/voila/pull/674) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2020-03-02&to=2020-08-17&type=c))
+
+[@afonit](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aafonit+updated%3A2020-03-02..2020-08-17&type=Issues) | [@anxhelahyseni](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aanxhelahyseni+updated%3A2020-03-02..2020-08-17&type=Issues) | [@brichet](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Abrichet+updated%3A2020-03-02..2020-08-17&type=Issues) | [@choldgraf](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Acholdgraf+updated%3A2020-03-02..2020-08-17&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Adavidbrochart+updated%3A2020-03-02..2020-08-17&type=Issues) | [@DougRzz](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ADougRzz+updated%3A2020-03-02..2020-08-17&type=Issues) | [@echarles](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aecharles+updated%3A2020-03-02..2020-08-17&type=Issues) | [@femiir](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Afemiir+updated%3A2020-03-02..2020-08-17&type=Issues) | [@fleimgruber](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Afleimgruber+updated%3A2020-03-02..2020-08-17&type=Issues) | [@gbrault](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Agbrault+updated%3A2020-03-02..2020-08-17&type=Issues) | [@GregSilverman](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AGregSilverman+updated%3A2020-03-02..2020-08-17&type=Issues) | [@jakemiller649](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajakemiller649+updated%3A2020-03-02..2020-08-17&type=Issues) | [@jasoriya](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajasoriya+updated%3A2020-03-02..2020-08-17&type=Issues) | [@jeffyjefflabs](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajeffyjefflabs+updated%3A2020-03-02..2020-08-17&type=Issues) | [@jmurray6](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajmurray6+updated%3A2020-03-02..2020-08-17&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2020-03-02..2020-08-17&type=Issues) | [@jwminton](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajwminton+updated%3A2020-03-02..2020-08-17&type=Issues) | [@kevin-bates](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Akevin-bates+updated%3A2020-03-02..2020-08-17&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Akrassowski+updated%3A2020-03-02..2020-08-17&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2020-03-02..2020-08-17&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AmartinRenou+updated%3A2020-03-02..2020-08-17&type=Issues) | [@mcg1969](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amcg1969+updated%3A2020-03-02..2020-08-17&type=Issues) | [@mgmarino](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amgmarino+updated%3A2020-03-02..2020-08-17&type=Issues) | [@mwouts](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amwouts+updated%3A2020-03-02..2020-08-17&type=Issues) | [@prachi-tripathi](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aprachi-tripathi+updated%3A2020-03-02..2020-08-17&type=Issues) | [@stefanmeili](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Astefanmeili+updated%3A2020-03-02..2020-08-17&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2020-03-02..2020-08-17&type=Issues) | [@timkpaine](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Atimkpaine+updated%3A2020-03-02..2020-08-17&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Avidartf+updated%3A2020-03-02..2020-08-17&type=Issues) | [@zerline](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Azerline+updated%3A2020-03-02..2020-08-17&type=Issues) | [@Zsailer](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AZsailer+updated%3A2020-03-02..2020-08-17&type=Issues)
+
+## 0.1.21
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.1.20...0.1.21))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2019-11-12&to=2020-03-02&type=c))
+
+[@b060149ee](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ab060149ee+updated%3A2019-11-12..2020-03-02&type=Issues) | [@berceanu](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aberceanu+updated%3A2019-11-12..2020-03-02&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Adavidbrochart+updated%3A2019-11-12..2020-03-02&type=Issues) | [@dkruijs](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Adkruijs+updated%3A2019-11-12..2020-03-02&type=Issues) | [@echarles](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aecharles+updated%3A2019-11-12..2020-03-02&type=Issues) | [@gbrault](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Agbrault+updated%3A2019-11-12..2020-03-02&type=Issues) | [@gedankenstuecke](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Agedankenstuecke+updated%3A2019-11-12..2020-03-02&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajasongrout+updated%3A2019-11-12..2020-03-02&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2019-11-12..2020-03-02&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2019-11-12..2020-03-02&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AmartinRenou+updated%3A2019-11-12..2020-03-02&type=Issues) | [@numice](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Anumice+updated%3A2019-11-12..2020-03-02&type=Issues) | [@stonebig](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Astonebig+updated%3A2019-11-12..2020-03-02&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2019-11-12..2020-03-02&type=Issues) | [@timkpaine](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Atimkpaine+updated%3A2019-11-12..2020-03-02&type=Issues) | [@TristanKnox](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ATristanKnox+updated%3A2019-11-12..2020-03-02&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Avidartf+updated%3A2019-11-12..2020-03-02&type=Issues) | [@Zsailer](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AZsailer+updated%3A2019-11-12..2020-03-02&type=Issues)
+
+## 0.1.20
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.1.19...0.1.20))
+
+### Merged PRs
+
+- Support nbconvert 5.5 [#476](https://github.com/voila-dashboards/voila/pull/476) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2019-11-12&to=2019-11-12&type=c))
+
+[@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2019-11-12..2019-11-12&type=Issues)
+
+## 0.1.19
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.1.18...0.1.19))
+
+### Merged PRs
+
+- Add cell error instruction configurable [#471](https://github.com/voila-dashboards/voila/pull/471) ([@aschlaep](https://github.com/aschlaep))
+- feat: execute cells in a thread, this will unblock the server's event loop [#403](https://github.com/voila-dashboards/voila/pull/403) ([@maartenbreddels](https://github.com/maartenbreddels))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2019-11-09&to=2019-11-12&type=c))
+
+[@aschlaep](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aaschlaep+updated%3A2019-11-09..2019-11-12&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2019-11-09..2019-11-12&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2019-11-09..2019-11-12&type=Issues)
+
+## 0.1.18
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.1.17...0.1.18))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2019-10-31&to=2019-11-09&type=c))
+
+[@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2019-10-31..2019-11-09&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2019-10-31..2019-11-09&type=Issues) | [@mariobuikhuizen](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amariobuikhuizen+updated%3A2019-10-31..2019-11-09&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AmartinRenou+updated%3A2019-10-31..2019-11-09&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2019-10-31..2019-11-09&type=Issues)
+
+## 0.1.17
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.1.16...0.1.17))
+
+## 0.1.16
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.1.15...0.1.16))
+
+### Merged PRs
+
+- Fixup voila configuration [#454](https://github.com/voila-dashboards/voila/pull/454) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2019-10-27&to=2019-10-29&type=c))
+
+[@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2019-10-27..2019-10-29&type=Issues) | [@mkcor](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amkcor+updated%3A2019-10-27..2019-10-29&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2019-10-27..2019-10-29&type=Issues)
+
+## 0.1.15
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.1.14...0.1.15))
+
+### Merged PRs
+
+- Include both jupyter_server and notebook server in README. [#450](https://github.com/voila-dashboards/voila/pull/450) ([@mkcor](https://github.com/mkcor))
+- Fix filtering of empty code cells. [#449](https://github.com/voila-dashboards/voila/pull/449) ([@mkcor](https://github.com/mkcor))
+- Spinner macro [#446](https://github.com/voila-dashboards/voila/pull/446) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Fix Binder link [#442](https://github.com/voila-dashboards/voila/pull/442) ([@jtpio](https://github.com/jtpio))
+- Update contributing guidelines [#441](https://github.com/voila-dashboards/voila/pull/441) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Use Jupyter visual identity [#440](https://github.com/voila-dashboards/voila/pull/440) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Allow comm open messages [#438](https://github.com/voila-dashboards/voila/pull/438) ([@saulshanabrook](https://github.com/saulshanabrook))
+- chore: improve release instructions and include ipywidgets as test dep [#436](https://github.com/voila-dashboards/voila/pull/436) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Load template-related config from JSON file. [#372](https://github.com/voila-dashboards/voila/pull/372) ([@mkcor](https://github.com/mkcor))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2019-10-17&to=2019-10-27&type=c))
+
+[@dschofield](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Adschofield+updated%3A2019-10-17..2019-10-27&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2019-10-17..2019-10-27&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2019-10-17..2019-10-27&type=Issues) | [@mkcor](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amkcor+updated%3A2019-10-17..2019-10-27&type=Issues) | [@saulshanabrook](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Asaulshanabrook+updated%3A2019-10-17..2019-10-27&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2019-10-17..2019-10-27&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Avidartf+updated%3A2019-10-17..2019-10-27&type=Issues)
+
+## 0.1.14
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.1.13...0.1.14))
+
+### Documentation improvements
+
+- DOC: README.md: typos [#401](https://github.com/voila-dashboards/voila/pull/401) ([@westurner](https://github.com/westurner))
+
+### Other merged PRs
+
+- Added a link to the documentation in the README.md [#430](https://github.com/voila-dashboards/voila/pull/430) ([@dkapila](https://github.com/dkapila))
+- fix: the voila side output widget did not handle error msges [#425](https://github.com/voila-dashboards/voila/pull/425) ([@maartenbreddels](https://github.com/maartenbreddels))
+- add auto port detection as in jupyter notebook [#424](https://github.com/voila-dashboards/voila/pull/424) ([@katsar0v](https://github.com/katsar0v))
+- Add .vscode to gitignore [#422](https://github.com/voila-dashboards/voila/pull/422) ([@jtpio](https://github.com/jtpio))
+- add note about installing and verifying the server extension [#420](https://github.com/voila-dashboards/voila/pull/420) ([@katsar0v](https://github.com/katsar0v))
+- Strip code cell warnings [#416](https://github.com/voila-dashboards/voila/pull/416) ([@GeorgianaElena](https://github.com/GeorgianaElena))
+- Clean templates [#415](https://github.com/voila-dashboards/voila/pull/415) ([@martinRenou](https://github.com/martinRenou))
+- Expose base_url to browser-open template [#413](https://github.com/voila-dashboards/voila/pull/413) ([@martinRenou](https://github.com/martinRenou))
+- Update package_lock [#409](https://github.com/voila-dashboards/voila/pull/409) ([@martinRenou](https://github.com/martinRenou))
+- Fix CSS name [#407](https://github.com/voila-dashboards/voila/pull/407) ([@martinRenou](https://github.com/martinRenou))
+- Check for 'outputs' key in the cell when stripping errors [#406](https://github.com/voila-dashboards/voila/pull/406) ([@martinRenou](https://github.com/martinRenou))
+- Update nbconvert [#404](https://github.com/voila-dashboards/voila/pull/404) ([@martinRenou](https://github.com/martinRenou))
+- Strip errors if not in debug mode [#398](https://github.com/voila-dashboards/voila/pull/398) ([@martinRenou](https://github.com/martinRenou))
+- Speed up progressive rendering [#396](https://github.com/voila-dashboards/voila/pull/396) ([@martinRenou](https://github.com/martinRenou))
+- Use Voila logo for the spinner [#393](https://github.com/voila-dashboards/voila/pull/393) ([@martinRenou](https://github.com/martinRenou))
+- Hide empty cells using CSS [#391](https://github.com/voila-dashboards/voila/pull/391) ([@martinRenou](https://github.com/martinRenou))
+- Add docs for deploying to Binder [#377](https://github.com/voila-dashboards/voila/pull/377) ([@jtpio](https://github.com/jtpio))
+- Add release instructions for @jupyter-voila/jupyterlab-preview [#371](https://github.com/voila-dashboards/voila/pull/371) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2019-10-03&to=2019-10-17&type=c))
+
+[@Alexboiboi](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AAlexboiboi+updated%3A2019-10-03..2019-10-17&type=Issues) | [@cailiang9](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Acailiang9+updated%3A2019-10-03..2019-10-17&type=Issues) | [@cantagallo](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Acantagallo+updated%3A2019-10-03..2019-10-17&type=Issues) | [@cmaureir](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Acmaureir+updated%3A2019-10-03..2019-10-17&type=Issues) | [@derek-pyne](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aderek-pyne+updated%3A2019-10-03..2019-10-17&type=Issues) | [@dkapila](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Adkapila+updated%3A2019-10-03..2019-10-17&type=Issues) | [@GeorgianaElena](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AGeorgianaElena+updated%3A2019-10-03..2019-10-17&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2019-10-03..2019-10-17&type=Issues) | [@katsar0v](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Akatsar0v+updated%3A2019-10-03..2019-10-17&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2019-10-03..2019-10-17&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AmartinRenou+updated%3A2019-10-03..2019-10-17&type=Issues) | [@MSeal](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AMSeal+updated%3A2019-10-03..2019-10-17&type=Issues) | [@sruthiiyer](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Asruthiiyer+updated%3A2019-10-03..2019-10-17&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2019-10-03..2019-10-17&type=Issues) | [@timkpaine](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Atimkpaine+updated%3A2019-10-03..2019-10-17&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Avidartf+updated%3A2019-10-03..2019-10-17&type=Issues) | [@westurner](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Awesturner+updated%3A2019-10-03..2019-10-17&type=Issues)
+
+## 0.1.13
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.1.12...0.1.13))
+
+### Merged PRs
+
+- fix: allow voila to run a server extension for notebook <5 [#390](https://github.com/voila-dashboards/voila/pull/390) ([@maartenbreddels](https://github.com/maartenbreddels))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2019-09-28&to=2019-10-03&type=c))
+
+[@anki-code](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aanki-code+updated%3A2019-09-28..2019-10-03&type=Issues) | [@hainm](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ahainm+updated%3A2019-09-28..2019-10-03&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2019-09-28..2019-10-03&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2019-09-28..2019-10-03&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AmartinRenou+updated%3A2019-09-28..2019-10-03&type=Issues) | [@robmarkcole](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Arobmarkcole+updated%3A2019-09-28..2019-10-03&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2019-09-28..2019-10-03&type=Issues) | [@timkpaine](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Atimkpaine+updated%3A2019-09-28..2019-10-03&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Avidartf+updated%3A2019-09-28..2019-10-03&type=Issues)
+
+## 0.1.12
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.1.11...0.1.12))
+
+### Merged PRs
+
+- Fix exporter for templates not using the progressive rendering [#389](https://github.com/voila-dashboards/voila/pull/389) ([@jtpio](https://github.com/jtpio))
+- New voila logo and visual identity [#386](https://github.com/voila-dashboards/voila/pull/386) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Update copyright statements before moving to voila-dashboards [#385](https://github.com/voila-dashboards/voila/pull/385) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2019-09-20&to=2019-09-28&type=c))
+
+[@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2019-09-20..2019-09-28&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2019-09-20..2019-09-28&type=Issues)
+
+## 0.1.11
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.1.10...0.1.11))
+
+### Merged PRs
+
+- Optimize svg icons, fix JLab 1.1 issue [#379](https://github.com/voila-dashboards/voila/pull/379) ([@jtpio](https://github.com/jtpio))
+- extra docs for running scripts [#373](https://github.com/voila-dashboards/voila/pull/373) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Docs update for v0.1.10 [#368](https://github.com/voila-dashboards/voila/pull/368) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Progressively render the template using jinja's generate method [#133](https://github.com/voila-dashboards/voila/pull/133) ([@maartenbreddels](https://github.com/maartenbreddels))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2019-08-28&to=2019-09-20&type=c))
+
+[@Alexboiboi](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AAlexboiboi+updated%3A2019-08-28..2019-09-20&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2019-08-28..2019-09-20&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2019-08-28..2019-09-20&type=Issues) | [@mkcor](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amkcor+updated%3A2019-08-28..2019-09-20&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2019-08-28..2019-09-20&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Avidartf+updated%3A2019-08-28..2019-09-20&type=Issues)
+
+## 0.1.10
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.1.9...0.1.10))
+
+### Merged PRs
+
+- feat: serve static files similar to the notebook [#361](https://github.com/voila-dashboards/voila/pull/361) ([@maartenbreddels](https://github.com/maartenbreddels))
+- fix: support nested output widgets in voila executor [#358](https://github.com/voila-dashboards/voila/pull/358) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Add instructions for sharing with ngrok to the docs [#353](https://github.com/voila-dashboards/voila/pull/353) ([@jtpio](https://github.com/jtpio))
+- Add the Voila Gallery to README.md [#348](https://github.com/voila-dashboards/voila/pull/348) ([@jtpio](https://github.com/jtpio))
+- Fix nbextension commands for local install [#343](https://github.com/voila-dashboards/voila/pull/343) ([@jtpio](https://github.com/jtpio))
+- Add RELEASE.md [#334](https://github.com/voila-dashboards/voila/pull/334) ([@jtpio](https://github.com/jtpio))
+- Feat: support script files [#330](https://github.com/voila-dashboards/voila/pull/330) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Monochrome voila icon for the notebook toolbar [#305](https://github.com/voila-dashboards/voila/pull/305) ([@jtpio](https://github.com/jtpio))
+- Switch to es2017 target for the JLab extension [#280](https://github.com/voila-dashboards/voila/pull/280) ([@jtpio](https://github.com/jtpio))
+- JLab extension: render the preview on save [#268](https://github.com/voila-dashboards/voila/pull/268) ([@jtpio](https://github.com/jtpio))
+- add deploy documentation for heroku and app engine [#229](https://github.com/voila-dashboards/voila/pull/229) ([@RensDimmendaal](https://github.com/RensDimmendaal))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2019-07-29&to=2019-08-28&type=c))
+
+[@anki-code](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aanki-code+updated%3A2019-07-29..2019-08-28&type=Issues) | [@astrojuanlu](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aastrojuanlu+updated%3A2019-07-29..2019-08-28&type=Issues) | [@benlindsay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Abenlindsay+updated%3A2019-07-29..2019-08-28&type=Issues) | [@berceanu](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aberceanu+updated%3A2019-07-29..2019-08-28&type=Issues) | [@firasm](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Afirasm+updated%3A2019-07-29..2019-08-28&type=Issues) | [@hainm](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ahainm+updated%3A2019-07-29..2019-08-28&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2019-07-29..2019-08-28&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2019-07-29..2019-08-28&type=Issues) | [@numice](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Anumice+updated%3A2019-07-29..2019-08-28&type=Issues) | [@pbugnion](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Apbugnion+updated%3A2019-07-29..2019-08-28&type=Issues) | [@RensDimmendaal](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ARensDimmendaal+updated%3A2019-07-29..2019-08-28&type=Issues) | [@robmarkcole](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Arobmarkcole+updated%3A2019-07-29..2019-08-28&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2019-07-29..2019-08-28&type=Issues) | [@timkpaine](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Atimkpaine+updated%3A2019-07-29..2019-08-28&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Avidartf+updated%3A2019-07-29..2019-08-28&type=Issues)
+
+## 0.1.9
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.1.8...0.1.9))
+
+### Merged PRs
+
+- help: show more configurable classes with --help-all, and use consistent naming [#331](https://github.com/voila-dashboards/voila/pull/331) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Fix example use for config attribute resources [#323](https://github.com/voila-dashboards/voila/pull/323) ([@mkcor](https://github.com/mkcor))
+- Fix Windows develop install [#322](https://github.com/voila-dashboards/voila/pull/322) ([@vidartf](https://github.com/vidartf))
+- test: set timeout of pytest_tornado to 20 seconds to avoid false CI failured [#321](https://github.com/voila-dashboards/voila/pull/321) ([@maartenbreddels](https://github.com/maartenbreddels))
+- fix: ignore non-jupyter-widget comm_open messages at the backend, causing 500 errors for users. [#319](https://github.com/voila-dashboards/voila/pull/319) ([@maartenbreddels](https://github.com/maartenbreddels))
+- feat: make the markdown rendered configurable in VoilaExporter [#317](https://github.com/voila-dashboards/voila/pull/317) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Clear output before executing the notebook [#314](https://github.com/voila-dashboards/voila/pull/314) ([@jeffyjefflabs](https://github.com/jeffyjefflabs))
+- Fix wording in default template tree [#312](https://github.com/voila-dashboards/voila/pull/312) ([@jtpio](https://github.com/jtpio))
+- Handle non-existing kernels [#309](https://github.com/voila-dashboards/voila/pull/309) ([@jtpio](https://github.com/jtpio))
+- Add --debug flag [#307](https://github.com/voila-dashboards/voila/pull/307) ([@jtpio](https://github.com/jtpio))
+- Passing custom resources to voila configuration [#301](https://github.com/voila-dashboards/voila/pull/301) ([@mkcor](https://github.com/mkcor))
+- Pass traitlets.config to ExecutePreprocessor [#240](https://github.com/voila-dashboards/voila/pull/240) ([@azjps](https://github.com/azjps))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2019-07-22&to=2019-07-29&type=c))
+
+[@azjps](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aazjps+updated%3A2019-07-22..2019-07-29&type=Issues) | [@farmani60](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Afarmani60+updated%3A2019-07-22..2019-07-29&type=Issues) | [@jeffyjefflabs](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajeffyjefflabs+updated%3A2019-07-22..2019-07-29&type=Issues) | [@jf---](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajf---+updated%3A2019-07-22..2019-07-29&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2019-07-22..2019-07-29&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2019-07-22..2019-07-29&type=Issues) | [@mkcor](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amkcor+updated%3A2019-07-22..2019-07-29&type=Issues) | [@pbadenski](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Apbadenski+updated%3A2019-07-22..2019-07-29&type=Issues) | [@samiit](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Asamiit+updated%3A2019-07-22..2019-07-29&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2019-07-22..2019-07-29&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Avidartf+updated%3A2019-07-22..2019-07-29&type=Issues)
+
+## 0.1.8
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.1.7...0.1.8))
+
+### Merged PRs
+
+- Voila manager constructor [#316](https://github.com/voila-dashboards/voila/pull/316) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Update jupyter_server to 0.1.0 [#308](https://github.com/voila-dashboards/voila/pull/308) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Full walkthrough on first install #303 [#304](https://github.com/voila-dashboards/voila/pull/304) ([@leogout](https://github.com/leogout))
+- README: Add JupyterLab extension install command [#300](https://github.com/voila-dashboards/voila/pull/300) ([@martinRenou](https://github.com/martinRenou))
+- Add pygments to install_requires [#297](https://github.com/voila-dashboards/voila/pull/297) ([@jtpio](https://github.com/jtpio))
+- Increase ulimit for testing [#295](https://github.com/voila-dashboards/voila/pull/295) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Add instructions to install dependencies of example notebooks [#294](https://github.com/voila-dashboards/voila/pull/294) ([@mkcor](https://github.com/mkcor))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2019-07-08&to=2019-07-22&type=c))
+
+[@janbucher](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajanbucher+updated%3A2019-07-08..2019-07-22&type=Issues) | [@jf---](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajf---+updated%3A2019-07-08..2019-07-22&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2019-07-08..2019-07-22&type=Issues) | [@leogout](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aleogout+updated%3A2019-07-08..2019-07-22&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2019-07-08..2019-07-22&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AmartinRenou+updated%3A2019-07-08..2019-07-22&type=Issues) | [@mkcor](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amkcor+updated%3A2019-07-08..2019-07-22&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2019-07-08..2019-07-22&type=Issues) | [@timkpaine](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Atimkpaine+updated%3A2019-07-08..2019-07-22&type=Issues) | [@tonywang531](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Atonywang531+updated%3A2019-07-08..2019-07-22&type=Issues)
+
+## 0.1.7
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.1.6...0.1.7))
+
+### Merged PRs
+
+- Fix tornado templates [#291](https://github.com/voila-dashboards/voila/pull/291) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Remove reference to jquery [#290](https://github.com/voila-dashboards/voila/pull/290) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2019-07-06&to=2019-07-08&type=c))
+
+[@DougRzz](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ADougRzz+updated%3A2019-07-06..2019-07-08&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2019-07-06..2019-07-08&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2019-07-06..2019-07-08&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2019-07-06..2019-07-08&type=Issues)
+
+## 0.1.6
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.1.5...0.1.6))
+
+### Merged PRs
+
+- Why is jquery loaded [#287](https://github.com/voila-dashboards/voila/pull/287) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2019-07-03&to=2019-07-06&type=c))
+
+[@dkruijs](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Adkruijs+updated%3A2019-07-03..2019-07-06&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2019-07-03..2019-07-06&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2019-07-03..2019-07-06&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Avidartf+updated%3A2019-07-03..2019-07-06&type=Issues)
+
+## 0.1.5
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.1.4...0.1.5))
+
+### Merged PRs
+
+- Black list the voila nbextension [#283](https://github.com/voila-dashboards/voila/pull/283) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Drop HTML manager [#282](https://github.com/voila-dashboards/voila/pull/282) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- JLab extension post release [#281](https://github.com/voila-dashboards/voila/pull/281) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2019-07-03&to=2019-07-03&type=c))
+
+[@DougRzz](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ADougRzz+updated%3A2019-07-03..2019-07-03&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2019-07-03..2019-07-03&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2019-07-03..2019-07-03&type=Issues)
+
+## 0.1.4
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.1.3...0.1.4))
+
+### Merged PRs
+
+- Update jlab extension to 1.0.0 [#279](https://github.com/voila-dashboards/voila/pull/279) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Use jupyterlab-manager 1.0, support for ipywidgets 7.5 [#277](https://github.com/voila-dashboards/voila/pull/277) ([@jtpio](https://github.com/jtpio))
+- requirejs should be loaded in the header with plotly [#275](https://github.com/voila-dashboards/voila/pull/275) ([@alexisduque](https://github.com/alexisduque))
+- Add server companion metadata [#273](https://github.com/voila-dashboards/voila/pull/273) ([@jtpio](https://github.com/jtpio))
+- Minor fix in the basics example notebook [#271](https://github.com/voila-dashboards/voila/pull/271) ([@jtpio](https://github.com/jtpio))
+- Update to JLab 1.0.0rc [#264](https://github.com/voila-dashboards/voila/pull/264) ([@jtpio](https://github.com/jtpio))
+- Update author to Voila contributors [#263](https://github.com/voila-dashboards/voila/pull/263) ([@jtpio](https://github.com/jtpio))
+- Save the notebook before showing the Voila preview [#262](https://github.com/voila-dashboards/voila/pull/262) ([@jtpio](https://github.com/jtpio))
+- JLab extension: minor fixes [#256](https://github.com/voila-dashboards/voila/pull/256) ([@jtpio](https://github.com/jtpio))
+- Use pytest-tornado instead of pytest-tornado5 [#254](https://github.com/voila-dashboards/voila/pull/254) ([@jtpio](https://github.com/jtpio))
+- Mention jupyter server extension in the tests docs [#253](https://github.com/voila-dashboards/voila/pull/253) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2019-06-17&to=2019-07-03&type=c))
+
+[@alexisduque](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aalexisduque+updated%3A2019-06-17..2019-07-03&type=Issues) | [@GregFa](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AGregFa+updated%3A2019-06-17..2019-07-03&type=Issues) | [@johntfoster](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajohntfoster+updated%3A2019-06-17..2019-07-03&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2019-06-17..2019-07-03&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2019-06-17..2019-07-03&type=Issues) | [@marcelo-ventura](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amarcelo-ventura+updated%3A2019-06-17..2019-07-03&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2019-06-17..2019-07-03&type=Issues) | [@timkpaine](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Atimkpaine+updated%3A2019-06-17..2019-07-03&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Avidartf+updated%3A2019-06-17..2019-07-03&type=Issues) | [@Zsailer](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AZsailer+updated%3A2019-06-17..2019-07-03&type=Issues)
+
+## 0.1.3
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.1.2...0.1.3))
+
+### Merged PRs
+
+- JLab: add toolbar and refresh button for the voila preview [#250](https://github.com/voila-dashboards/voila/pull/250) ([@jtpio](https://github.com/jtpio))
+- Fix support for Jupyter widget display in output widget [#249](https://github.com/voila-dashboards/voila/pull/249) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Launch browser after listening [#243](https://github.com/voila-dashboards/voila/pull/243) ([@jtpio](https://github.com/jtpio))
+- Shut down kernels after running the tests [#242](https://github.com/voila-dashboards/voila/pull/242) ([@jtpio](https://github.com/jtpio))
+- Add instruction to install the test_template [#241](https://github.com/voila-dashboards/voila/pull/241) ([@jtpio](https://github.com/jtpio))
+- Minor python2 fix [#236](https://github.com/voila-dashboards/voila/pull/236) ([@azjps](https://github.com/azjps))
+- Run flake8 on tests dir and setup.py [#235](https://github.com/voila-dashboards/voila/pull/235) ([@martinRenou](https://github.com/martinRenou))
+- Update license in package.json [#233](https://github.com/voila-dashboards/voila/pull/233) ([@martinRenou](https://github.com/martinRenou))
+- Fix typo [#230](https://github.com/voila-dashboards/voila/pull/230) ([@davidbrochart](https://github.com/davidbrochart))
+- Undefined name: from io import BytesIO for line 178 [#228](https://github.com/voila-dashboards/voila/pull/228) ([@cclauss](https://github.com/cclauss))
+- Fixup documentation images [#223](https://github.com/voila-dashboards/voila/pull/223) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Convert voila-square icon to path [#222](https://github.com/voila-dashboards/voila/pull/222) ([@jtpio](https://github.com/jtpio))
+- JupyterLab extension [#217](https://github.com/voila-dashboards/voila/pull/217) ([@jtpio](https://github.com/jtpio))
+- Remove gridstack from test dependencies [#207](https://github.com/voila-dashboards/voila/pull/207) ([@martinRenou](https://github.com/martinRenou))
+- Only use VoilaHandler for .ipynb files [#191](https://github.com/voila-dashboards/voila/pull/191) ([@martinRenou](https://github.com/martinRenou))
+- Add CONTRIBUTING.md [#161](https://github.com/voila-dashboards/voila/pull/161) ([@jtpio](https://github.com/jtpio))
+- Fix undefined manager [#106](https://github.com/voila-dashboards/voila/pull/106) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2019-06-10&to=2019-06-17&type=c))
+
+[@azjps](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aazjps+updated%3A2019-06-10..2019-06-17&type=Issues) | [@cclauss](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Acclauss+updated%3A2019-06-10..2019-06-17&type=Issues) | [@choldgraf](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Acholdgraf+updated%3A2019-06-10..2019-06-17&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Adavidbrochart+updated%3A2019-06-10..2019-06-17&type=Issues) | [@ericmjl](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aericmjl+updated%3A2019-06-10..2019-06-17&type=Issues) | [@johntfoster](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajohntfoster+updated%3A2019-06-10..2019-06-17&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2019-06-10..2019-06-17&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2019-06-10..2019-06-17&type=Issues) | [@Magnus512](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AMagnus512+updated%3A2019-06-10..2019-06-17&type=Issues) | [@marcelo-ventura](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amarcelo-ventura+updated%3A2019-06-10..2019-06-17&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AmartinRenou+updated%3A2019-06-10..2019-06-17&type=Issues) | [@mwouts](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amwouts+updated%3A2019-06-10..2019-06-17&type=Issues) | [@ostrokach](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aostrokach+updated%3A2019-06-10..2019-06-17&type=Issues) | [@pbugnion](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Apbugnion+updated%3A2019-06-10..2019-06-17&type=Issues) | [@philippjfr](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aphilippjfr+updated%3A2019-06-10..2019-06-17&type=Issues) | [@rladeira](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Arladeira+updated%3A2019-06-10..2019-06-17&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2019-06-10..2019-06-17&type=Issues) | [@timkpaine](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Atimkpaine+updated%3A2019-06-10..2019-06-17&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Avidartf+updated%3A2019-06-10..2019-06-17&type=Issues) | [@wolfv](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Awolfv+updated%3A2019-06-10..2019-06-17&type=Issues) | [@Zsailer](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AZsailer+updated%3A2019-06-10..2019-06-17&type=Issues)
+
+## 0.1.2
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.1.1...0.1.2))
+
+### Merged PRs
+
+- Update binder with cling and improve screencasts [#213](https://github.com/voila-dashboards/voila/pull/213) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Add C++ screencast [#212](https://github.com/voila-dashboards/voila/pull/212) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Add screencast with the C++ kernel [#211](https://github.com/voila-dashboards/voila/pull/211) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Add basic screencasts [#210](https://github.com/voila-dashboards/voila/pull/210) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Update distribution [#205](https://github.com/voila-dashboards/voila/pull/205) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Adds styling and a header to the voila tree [#200](https://github.com/voila-dashboards/voila/pull/200) ([@DanielAristidou](https://github.com/DanielAristidou))
+- Add logo [#196](https://github.com/voila-dashboards/voila/pull/196) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2019-06-06&to=2019-06-10&type=c))
+
+[@DanielAristidou](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ADanielAristidou+updated%3A2019-06-06..2019-06-10&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2019-06-06..2019-06-10&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2019-06-06..2019-06-10&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AmartinRenou+updated%3A2019-06-06..2019-06-10&type=Issues) | [@scottlittle](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ascottlittle+updated%3A2019-06-06..2019-06-10&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2019-06-06..2019-06-10&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Avidartf+updated%3A2019-06-06..2019-06-10&type=Issues)
+
+## 0.1.1
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.1.0...0.1.1))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2019-06-05&to=2019-06-06&type=c))
+
+[@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2019-06-05..2019-06-06&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2019-06-05..2019-06-06&type=Issues)
+
+## 0.0.14
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.0.13...0.0.14))
+
+### Merged PRs
+
+- don't 500 on cell execution errors [#186](https://github.com/voila-dashboards/voila/pull/186) ([@ivanov](https://github.com/ivanov))
+- Add flag for nbextensions [#185](https://github.com/voila-dashboards/voila/pull/185) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Expose phosphor [#183](https://github.com/voila-dashboards/voila/pull/183) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- add top-level serverextension and installation instructions [#182](https://github.com/voila-dashboards/voila/pull/182) ([@ivanov](https://github.com/ivanov))
+- Add @web.autenticated to /voila/tree [#181](https://github.com/voila-dashboards/voila/pull/181) ([@jtpio](https://github.com/jtpio))
+- Review example notebooks [#178](https://github.com/voila-dashboards/voila/pull/178) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Update environment.yml [#177](https://github.com/voila-dashboards/voila/pull/177) ([@lheagy](https://github.com/lheagy))
+- Fixup nbextension [#176](https://github.com/voila-dashboards/voila/pull/176) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Add ipympl example [#175](https://github.com/voila-dashboards/voila/pull/175) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Wrap rendering with try-catch clauses to handle closed widgets [#172](https://github.com/voila-dashboards/voila/pull/172) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- adding information about customizing voila and static files [#168](https://github.com/voila-dashboards/voila/pull/168) ([@choldgraf](https://github.com/choldgraf))
+- Remove style inconsistencies from the docs [#167](https://github.com/voila-dashboards/voila/pull/167) ([@pbugnion](https://github.com/pbugnion))
+- Add ipynb extension in tree handler and voila handler url [#165](https://github.com/voila-dashboards/voila/pull/165) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2019-05-28&to=2019-06-05&type=c))
+
+[@astrojuanlu](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aastrojuanlu+updated%3A2019-05-28..2019-06-05&type=Issues) | [@choldgraf](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Acholdgraf+updated%3A2019-05-28..2019-06-05&type=Issues) | [@evanlynch](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aevanlynch+updated%3A2019-05-28..2019-06-05&type=Issues) | [@ivanov](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aivanov+updated%3A2019-05-28..2019-06-05&type=Issues) | [@jeffyjefflabs](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajeffyjefflabs+updated%3A2019-05-28..2019-06-05&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2019-05-28..2019-06-05&type=Issues) | [@lheagy](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Alheagy+updated%3A2019-05-28..2019-06-05&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2019-05-28..2019-06-05&type=Issues) | [@pbugnion](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Apbugnion+updated%3A2019-05-28..2019-06-05&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2019-05-28..2019-06-05&type=Issues) | [@timkpaine](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Atimkpaine+updated%3A2019-05-28..2019-06-05&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Avidartf+updated%3A2019-05-28..2019-06-05&type=Issues)
+
+## 0.0.13
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.0.12...0.0.13))
+
+### Merged PRs
+
+- Test voila --help [#164](https://github.com/voila-dashboards/voila/pull/164) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2019-05-28&to=2019-05-28&type=c))
+
+[@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2019-05-28..2019-05-28&type=Issues)
+
+## 0.0.11
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.0.10...0.0.11))
+
+### Documentation improvements
+
+- DOC: Clarify voila --help command [#103](https://github.com/voila-dashboards/voila/pull/103) ([@pllim](https://github.com/pllim))
+
+### Other merged PRs
+
+- Remove gridstack template [#163](https://github.com/voila-dashboards/voila/pull/163) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Use nbconvert stable [#162](https://github.com/voila-dashboards/voila/pull/162) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Use plural for template(s) data dir [#159](https://github.com/voila-dashboards/voila/pull/159) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Enable bqplot 0.11.x themes [#157](https://github.com/voila-dashboards/voila/pull/157) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Drop postcss [#156](https://github.com/voila-dashboards/voila/pull/156) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Use jupyterlab_pygments to generate syntax coloring CSS [#155](https://github.com/voila-dashboards/voila/pull/155) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Remove locally built css [#151](https://github.com/voila-dashboards/voila/pull/151) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- feature(configuration): server extension shares configuration with voila app [#148](https://github.com/voila-dashboards/voila/pull/148) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Refactor voila js [#147](https://github.com/voila-dashboards/voila/pull/147) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Add missing copyright headers [#146](https://github.com/voila-dashboards/voila/pull/146) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- fix(build): add missing presets for babel [#144](https://github.com/voila-dashboards/voila/pull/144) ([@mariobuikhuizen](https://github.com/mariobuikhuizen))
+- Dev mode detect [#138](https://github.com/voila-dashboards/voila/pull/138) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Give an error when a template is not found [#137](https://github.com/voila-dashboards/voila/pull/137) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Introduce new JupyterLab template [#131](https://github.com/voila-dashboards/voila/pull/131) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- updating documentation [#126](https://github.com/voila-dashboards/voila/pull/126) ([@choldgraf](https://github.com/choldgraf))
+- Reverse proxy [#115](https://github.com/voila-dashboards/voila/pull/115) ([@timkpaine](https://github.com/timkpaine))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2019-05-14&to=2019-05-28&type=c))
+
+[@afeiszli](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aafeiszli+updated%3A2019-05-14..2019-05-28&type=Issues) | [@candronikos](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Acandronikos+updated%3A2019-05-14..2019-05-28&type=Issues) | [@choldgraf](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Acholdgraf+updated%3A2019-05-14..2019-05-28&type=Issues) | [@DentonGentry](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ADentonGentry+updated%3A2019-05-14..2019-05-28&type=Issues) | [@gbrault](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Agbrault+updated%3A2019-05-14..2019-05-28&type=Issues) | [@jeffyjefflabs](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajeffyjefflabs+updated%3A2019-05-14..2019-05-28&type=Issues) | [@jonsnowseven](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajonsnowseven+updated%3A2019-05-14..2019-05-28&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2019-05-14..2019-05-28&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2019-05-14..2019-05-28&type=Issues) | [@mariobuikhuizen](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amariobuikhuizen+updated%3A2019-05-14..2019-05-28&type=Issues) | [@pllim](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Apllim+updated%3A2019-05-14..2019-05-28&type=Issues) | [@scottlittle](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ascottlittle+updated%3A2019-05-14..2019-05-28&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2019-05-14..2019-05-28&type=Issues) | [@timkpaine](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Atimkpaine+updated%3A2019-05-14..2019-05-28&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Avidartf+updated%3A2019-05-14..2019-05-28&type=Issues)
+
+## 0.0.10
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.0.9...0.0.10))
+
+### Merged PRs
+
+- Usability: Open browser, display url and shortcut to serving directory [#136](https://github.com/voila-dashboards/voila/pull/136) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Fix: set cwd of kernel and pass to nbconvert [#132](https://github.com/voila-dashboards/voila/pull/132) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Add data-base-url to the default template body [#109](https://github.com/voila-dashboards/voila/pull/109) ([@jtpio](https://github.com/jtpio))
+- new: render image inline in html [#101](https://github.com/voila-dashboards/voila/pull/101) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Fix displayed not triggered [#97](https://github.com/voila-dashboards/voila/pull/97) ([@maartenbreddels](https://github.com/maartenbreddels))
+- travis: fix: nbconvert widget_state is merged [#96](https://github.com/voila-dashboards/voila/pull/96) ([@maartenbreddels](https://github.com/maartenbreddels))
+- fix: work with master of nbconvert [#93](https://github.com/voila-dashboards/voila/pull/93) ([@maartenbreddels](https://github.com/maartenbreddels))
+- use jupyter server 0.0.4 [#92](https://github.com/voila-dashboards/voila/pull/92) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Implement Output widget at nbconvert level for interact [#91](https://github.com/voila-dashboards/voila/pull/91) ([@maartenbreddels](https://github.com/maartenbreddels))
+- More testing / more coverage [#86](https://github.com/voila-dashboards/voila/pull/86) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Configure voila using traitlets configuration system [#84](https://github.com/voila-dashboards/voila/pull/84) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Allow starting voila from an instance [#83](https://github.com/voila-dashboards/voila/pull/83) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Refactor and extend tests / expose and fix template bug [#81](https://github.com/voila-dashboards/voila/pull/81) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Expose **version** [#79](https://github.com/voila-dashboards/voila/pull/79) ([@jtpio](https://github.com/jtpio))
+- Tornado6 support [#74](https://github.com/voila-dashboards/voila/pull/74) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Fixes for templates, add support for tornado settings [#69](https://github.com/voila-dashboards/voila/pull/69) ([@timkpaine](https://github.com/timkpaine))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2019-03-07&to=2019-05-14&type=c))
+
+[@afeiszli](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aafeiszli+updated%3A2019-03-07..2019-05-14&type=Issues) | [@betatim](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Abetatim+updated%3A2019-03-07..2019-05-14&type=Issues) | [@choldgraf](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Acholdgraf+updated%3A2019-03-07..2019-05-14&type=Issues) | [@danlester](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Adanlester+updated%3A2019-03-07..2019-05-14&type=Issues) | [@DougRzz](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ADougRzz+updated%3A2019-03-07..2019-05-14&type=Issues) | [@enryH](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AenryH+updated%3A2019-03-07..2019-05-14&type=Issues) | [@evanlynch](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aevanlynch+updated%3A2019-03-07..2019-05-14&type=Issues) | [@freddupont](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Afreddupont+updated%3A2019-03-07..2019-05-14&type=Issues) | [@gedankenstuecke](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Agedankenstuecke+updated%3A2019-03-07..2019-05-14&type=Issues) | [@jeffyjefflabs](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajeffyjefflabs+updated%3A2019-03-07..2019-05-14&type=Issues) | [@jf---](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajf---+updated%3A2019-03-07..2019-05-14&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2019-03-07..2019-05-14&type=Issues) | [@leogout](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aleogout+updated%3A2019-03-07..2019-05-14&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2019-03-07..2019-05-14&type=Issues) | [@marcocaggioni](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amarcocaggioni+updated%3A2019-03-07..2019-05-14&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AmartinRenou+updated%3A2019-03-07..2019-05-14&type=Issues) | [@mkcor](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amkcor+updated%3A2019-03-07..2019-05-14&type=Issues) | [@mrichnu](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amrichnu+updated%3A2019-03-07..2019-05-14&type=Issues) | [@mwouts](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amwouts+updated%3A2019-03-07..2019-05-14&type=Issues) | [@pllim](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Apllim+updated%3A2019-03-07..2019-05-14&type=Issues) | [@sntgluca](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Asntgluca+updated%3A2019-03-07..2019-05-14&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2019-03-07..2019-05-14&type=Issues) | [@timkpaine](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Atimkpaine+updated%3A2019-03-07..2019-05-14&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Avidartf+updated%3A2019-03-07..2019-05-14&type=Issues) | [@yuvipanda](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ayuvipanda+updated%3A2019-03-07..2019-05-14&type=Issues)
+
+## 0.0.9
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.0.8...0.0.9))
+
+### Merged PRs
+
+- Fixing up jupyter server extension [#73](https://github.com/voila-dashboards/voila/pull/73) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Document collect_template_paths [#68](https://github.com/voila-dashboards/voila/pull/68) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Shutdown kernels on exit and SIGTERM [#65](https://github.com/voila-dashboards/voila/pull/65) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Linting [#64](https://github.com/voila-dashboards/voila/pull/64) ([@timkpaine](https://github.com/timkpaine))
+- feat: use jupyterlab-manager output widget [#46](https://github.com/voila-dashboards/voila/pull/46) ([@msuperina](https://github.com/msuperina))
+- Setting up testing [#42](https://github.com/voila-dashboards/voila/pull/42) ([@maartenbreddels](https://github.com/maartenbreddels))
+- require should not timeout after 7 seconds, solves #31 [#38](https://github.com/voila-dashboards/voila/pull/38) ([@maartenbreddels](https://github.com/maartenbreddels))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2019-01-24&to=2019-03-07&type=c))
+
+[@candronikos](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Acandronikos+updated%3A2019-01-24..2019-03-07&type=Issues) | [@DentonGentry](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ADentonGentry+updated%3A2019-01-24..2019-03-07&type=Issues) | [@ericmjl](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aericmjl+updated%3A2019-01-24..2019-03-07&type=Issues) | [@farmani60](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Afarmani60+updated%3A2019-01-24..2019-03-07&type=Issues) | [@gbrault](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Agbrault+updated%3A2019-01-24..2019-03-07&type=Issues) | [@jeffyjefflabs](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajeffyjefflabs+updated%3A2019-01-24..2019-03-07&type=Issues) | [@jf---](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajf---+updated%3A2019-01-24..2019-03-07&type=Issues) | [@jonsnowseven](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajonsnowseven+updated%3A2019-01-24..2019-03-07&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2019-01-24..2019-03-07&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2019-01-24..2019-03-07&type=Issues) | [@mathematicalmichael](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amathematicalmichael+updated%3A2019-01-24..2019-03-07&type=Issues) | [@msuperina](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amsuperina+updated%3A2019-01-24..2019-03-07&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2019-01-24..2019-03-07&type=Issues) | [@timkpaine](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Atimkpaine+updated%3A2019-01-24..2019-03-07&type=Issues)
+
+## 0.0.8
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.0.7...0.0.8))
+
+### Merged PRs
+
+- Fixup template path [#53](https://github.com/voila-dashboards/voila/pull/53) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2019-01-24&to=2019-01-24&type=c))
+
+[@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2019-01-24..2019-01-24&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2019-01-24..2019-01-24&type=Issues)
+
+## 0.0.7
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.0.6...0.0.7))
+
+### Merged PRs
+
+- Use classical notebook extension mechanism for enabling e.g. widgets [#50](https://github.com/voila-dashboards/voila/pull/50) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Move to flexible lightweight template system [#49](https://github.com/voila-dashboards/voila/pull/49) ([@maartenbreddels](https://github.com/maartenbreddels))
+- Add support for `python -m voila` [#47](https://github.com/voila-dashboards/voila/pull/47) ([@jtpio](https://github.com/jtpio))
+- Return version with `voila --version` [#44](https://github.com/voila-dashboards/voila/pull/44) ([@jtpio](https://github.com/jtpio))
+- Add voila button for classical notebook, ala appmode [#37](https://github.com/voila-dashboards/voila/pull/37) ([@maartenbreddels](https://github.com/maartenbreddels))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2018-12-03&to=2019-01-24&type=c))
+
+[@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2018-12-03..2019-01-24&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2018-12-03..2019-01-24&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2018-12-03..2019-01-24&type=Issues) | [@timkpaine](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Atimkpaine+updated%3A2018-12-03..2019-01-24&type=Issues)
+
+## 0.0.6
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.0.5...0.0.6))
+
+### Merged PRs
+
+- Support Python < 3.6 [#32](https://github.com/voila-dashboards/voila/pull/32) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Use html-manager 0.15.2 [#28](https://github.com/voila-dashboards/voila/pull/28) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Add documentation skeleton [#26](https://github.com/voila-dashboards/voila/pull/26) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Expose HTMLExporter configuration [#25](https://github.com/voila-dashboards/voila/pull/25) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2018-11-20&to=2018-12-03&type=c))
+
+[@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2018-11-20..2018-12-03&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2018-11-20..2018-12-03&type=Issues) | [@timkpaine](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Atimkpaine+updated%3A2018-11-20..2018-12-03&type=Issues)
+
+## 0.0.5
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.0.4...0.0.5))
+
+### Merged PRs
+
+- Use latest version of Jupyter services [#18](https://github.com/voila-dashboards/voila/pull/18) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Make reusing voila easier with custom template + gridstack example [#14](https://github.com/voila-dashboards/voila/pull/14) ([@maartenbreddels](https://github.com/maartenbreddels))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2018-10-29&to=2018-11-20&type=c))
+
+[@ericmjl](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aericmjl+updated%3A2018-10-29..2018-11-20&type=Issues) | [@freddupont](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Afreddupont+updated%3A2018-10-29..2018-11-20&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2018-10-29..2018-11-20&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2018-10-29..2018-11-20&type=Issues) | [@mathematicalmichael](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amathematicalmichael+updated%3A2018-10-29..2018-11-20&type=Issues) | [@msuperina](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amsuperina+updated%3A2018-10-29..2018-11-20&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2018-10-29..2018-11-20&type=Issues) | [@timkpaine](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Atimkpaine+updated%3A2018-10-29..2018-11-20&type=Issues)
+
+## 0.0.4
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.0.3...0.0.4))
+
+### Merged PRs
+
+- Fixup ipyvolume loading example [#12](https://github.com/voila-dashboards/voila/pull/12) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2018-10-17&to=2018-10-29&type=c))
+
+[@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2018-10-17..2018-10-29&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2018-10-17..2018-10-29&type=Issues)
+
+## 0.0.3
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.0.2...0.0.3))
+
+### Merged PRs
+
+- Cleanup package [#10](https://github.com/voila-dashboards/voila/pull/10) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2018-10-16&to=2018-10-17&type=c))
+
+[@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2018-10-16..2018-10-17&type=Issues)
+
+## 0.0.2
+
+([full changelog](https://github.com/voila-dashboards/voila/compare/0.0.1...0.0.2))
+
+### Merged PRs
+
+- Cleanup and support base url [#8](https://github.com/voila-dashboards/voila/pull/8) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+- Reuse voila to be a server extension + tree view + autoreload [#2](https://github.com/voila-dashboards/voila/pull/2) ([@maartenbreddels](https://github.com/maartenbreddels))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2018-09-07&to=2018-10-16&type=c))
+
+[@jasongrout](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajasongrout+updated%3A2018-09-07..2018-10-16&type=Issues) | [@maartenbreddels](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amaartenbreddels+updated%3A2018-09-07..2018-10-16&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2018-09-07..2018-10-16&type=Issues)


### PR DESCRIPTION
Fixes #369 

Bootstrap a `CHANGELOG.md` with a temporary script using `github-activity`.

This file will have to be continuously updated when new releases are cut (will be automated with #805). We can then also use the set of labels that `github-activity` understands to tag issues and PRs, so they are nicely summarized in the changelog when cutting a release.

## Changes

- [x] Create `CHANGELOG.md` 
- [x] Add missing releases
- [x] Make it compatible with the jupyter releaser