### PR TITLE
http_header_envs option to include http headers as an env var (following CGI standards)

### DIFF
--- a/voila/configuration.py
+++ b/voila/configuration.py
@@ -99,3 +99,12 @@ class VoilaConfiguration(traitlets.config.Configurable):
         for example a kernel manager with support for pooling.
         """
     )
+
+    http_header_envs = List(
+        Unicode(),
+        [],
+        help=r"""
+    List of HTTP Headers that should be passed as env vars to the kernel.
+    Example: --VoilaConfiguration.http_header_envs="['X-CDSDASHBOARDS-JH-USER']"
+    """,
+    ).tag(config=True)

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -11,7 +11,6 @@ import asyncio
 import os
 import sys
 import traceback
-import json
 
 import tornado.web
 
@@ -82,13 +81,14 @@ class VoilaHandler(JupyterHandler):
         self.kernel_env['SERVER_PORT'] = str(port) if port else ''
         self.kernel_env['SERVER_NAME'] = host
 
-        # Add HTTP Headers as env vars
+        # Add HTTP Headers as env vars following rfc3875#section-4.1.18
         if len(self.voila_configuration.http_header_envs) > 0:
-            http_headers_dict = {}
-            for header_name in self.voila_configuration.http_header_envs:
-                if header_name in self.request.headers:
-                    http_headers_dict[header_name] = self.request.headers.get(header_name)
-            self.kernel_env['HTTP_HEADERS'] = json.dumps(http_headers_dict)
+            config_headers_lower = [header.lower() for header in self.voila_configuration.http_header_envs]
+            for header_name in self.request.headers:
+                # Use case insensitive comparison of header names as per rfc2616#section-4.2
+                if header_name.lower() in config_headers_lower:
+                    env_name = f'HTTP_{header_name.upper().replace("-", "_")}'
+                    self.kernel_env[env_name] = self.request.headers.get(header_name)
 
         # we can override the template via notebook metadata or a query parameter
         template_override = None

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -11,6 +11,7 @@ import asyncio
 import os
 import sys
 import traceback
+import json
 
 import tornado.web
 
@@ -80,6 +81,15 @@ class VoilaHandler(JupyterHandler):
         host, port = split_host_and_port(self.request.host.lower())
         self.kernel_env['SERVER_PORT'] = str(port) if port else ''
         self.kernel_env['SERVER_NAME'] = host
+
+        # Add HTTP Headers as env vars
+        if len(self.voila_configuration.http_header_envs) > 0:
+            http_headers_dict = {}
+            for header_name in self.voila_configuration.http_header_envs:
+                if header_name in self.request.headers:
+                    http_headers_dict[header_name] = self.request.headers.get(header_name)
+            
+            self.kernel_env['HTTP_HEADERS'] = json.dumps(http_headers_dict)
 
         # we can override the template via notebook metadata or a query parameter
         template_override = None

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -88,7 +88,6 @@ class VoilaHandler(JupyterHandler):
             for header_name in self.voila_configuration.http_header_envs:
                 if header_name in self.request.headers:
                     http_headers_dict[header_name] = self.request.headers.get(header_name)
-            
             self.kernel_env['HTTP_HEADERS'] = json.dumps(http_headers_dict)
 
         # we can override the template via notebook metadata or a query parameter


### PR DESCRIPTION
Continuation of #835 with CGI standards applied.

To try it out:
```
voila --VoilaConfiguration.http_header_envs=uSeR-agEnt my_notebook.ipynb
```

in my_notebook.ipynb
```python
import os
print(os.environ.get('HTTP_USER_AGENT', 'User agent env var not found'))
```