### PR TITLE
Handle the case when one widget model fails to be created

### DIFF
--- a/packages/voila/src/manager.ts
+++ b/packages/voila/src/manager.ts
@@ -217,18 +217,23 @@ export class WidgetManager extends JupyterLabManager {
     await Promise.all(
       widgets_info.map(async widget_info => {
         const state = (widget_info as any).msg.content.data.state;
-        const modelPromise = this.new_model(
-          {
-            model_name: state._model_name,
-            model_module: state._model_module,
-            model_module_version: state._model_module_version,
-            comm: (widget_info as any).comm
-          },
-          state
-        );
-        const model = await modelPromise;
-        models[model.model_id] = model;
-        return modelPromise;
+        try {
+          const modelPromise = this.new_model(
+            {
+              model_name: state._model_name,
+              model_module: state._model_module,
+              model_module_version: state._model_module_version,
+              comm: (widget_info as any).comm
+            },
+            state
+          );
+          const model = await modelPromise;
+          models[model.model_id] = model;
+        } catch (error) {
+          // Failed to create a widget model, we continue creating other models so that
+          // other widgets can render
+          console.error(error);
+        }
       })
     );
     return models;


### PR DESCRIPTION
## Code changes

Handle the case when one widget model fails to be created, so that other widgets in the page can be rendered anyway.

This behavior is closer to other front-ends like JupyterLab.

## Reproduce

The following Notebook code can reproduce the issue. Here the grid model is invalid and throws an error when being created.

Due to this error, the slider could not be rendered.


```python
# Cell 1
from ipywidgets import Tab, IntSlider

tab = Tab()

import pandas as pd
from ipydatagrid import DataGrid, TextRenderer, VegaExpr

df = pd.DataFrame(
    {
        "column 1": [{"key": 11}, ["berry", "apple", "cherry"]],
        "column 2": [["berry", "berry", "cherry"], {"key": 10}],
    }
)

renderer = TextRenderer(
    background_color=VegaExpr(
        "cell.value[1] == 'berry' && cell.metadata.data['column 1']['key'] == 11 ? 'limegreen' # : 'pink'"
    )
)

tab.children = [DataGrid(
    df,
    layout={"height": "100px"},
    base_column_size=150,
    default_renderer=renderer,
), IntSlider()]
tab

# Cell 2

print('hey')

# Cell 3
IntSlider()
```

Result before this PR (the slider cannot render):
![voilaold](https://user-images.githubusercontent.com/21197331/131640970-22f3af75-bd85-4654-a72e-2f195fbab78f.png)

Result after this PR (the slider can render):
![voilanew](https://user-images.githubusercontent.com/21197331/131640994-2b7a4c7e-0fa9-404c-9d0f-8292e2b35931.png)

