### PR TITLE
Add `allow-popups` and `allow-modals` to the preview sandbox

### DIFF
--- a/packages/jupyterlab-preview/src/preview.tsx
+++ b/packages/jupyterlab-preview/src/preview.tsx
@@ -51,6 +51,7 @@ export class VoilaPreview extends DocumentWidget<IFrame, INotebookModel> {
           'allow-same-origin',
           'allow-scripts',
           'allow-downloads',
+          'allow-modals',
           'allow-popups'
         ]
       })

--- a/packages/jupyterlab-preview/src/preview.tsx
+++ b/packages/jupyterlab-preview/src/preview.tsx
@@ -47,7 +47,12 @@ export class VoilaPreview extends DocumentWidget<IFrame, INotebookModel> {
     super({
       ...options,
       content: new IFrame({
-        sandbox: ['allow-same-origin', 'allow-scripts', 'allow-downloads']
+        sandbox: [
+          'allow-same-origin',
+          'allow-scripts',
+          'allow-downloads',
+          'allow-popups'
+        ]
       })
     });
 


### PR DESCRIPTION
<!--
Thanks for contributing to Voilà!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/voila-dashboards/voila/blob/master/CONTRIBUTING.md
-->

## References

Fixes https://github.com/voila-dashboards/voila/pull/931#issuecomment-912586649

<!-- Note issue numbers this pull request addresses. -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Add `allow-popups` and `allow-modals` to the JupyterLab Preview IFrame sandbox.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Users can display popups in the JupyterLab preview. 

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to Voilà public APIs. -->
