### PR TITLE
Add a script to bump the version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,19 @@
+[bumpversion]
+current_version = 0, 2, 11, 'final', 0
+commit = False
+tag = False
+parse = (?P<major>\d+)\,\ (?P<minor>\d+)\,\ (?P<patch>\d+)\,\ \'(?P<release>\S+)\'\,\ (?P<build>\d+)
+serialize =
+	{major}, {minor}, {patch}, '{release}', {build}
+
+[bumpversion:part:release]
+optional_value = final
+values =
+	alpha
+	beta
+	candidate
+	final
+
+[bumpversion:part:build]
+
+[bumpversion:file:voila/_version.py]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,10 +1,10 @@
 [bumpversion]
-current_version = 0, 2, 11, 'final', 0
+current_version = 0, 2, 11, "final", 0
 commit = False
 tag = False
-parse = (?P<major>\d+)\,\ (?P<minor>\d+)\,\ (?P<patch>\d+)\,\ \'(?P<release>\S+)\'\,\ (?P<build>\d+)
+parse = (?P<major>\d+)\,\ (?P<minor>\d+)\,\ (?P<patch>\d+)\,\ \"(?P<release>\S+)\"\,\ (?P<build>\d+)
 serialize =
-	{major}, {minor}, {patch}, '{release}', {build}
+	{major}, {minor}, {patch}, "{release}", {build}
 
 [bumpversion:part:release]
 optional_value = final

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -16,19 +16,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
       - name: Install Python
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
           architecture: 'x64'
+
       - name: Install node
         uses: actions/setup-node@v2
         with:
           node-version: '14.x'
+
       - name: Get pip cache dir
         id: pip-cache
         run: |
           echo "::set-output name=dir::$(pip cache dir)"
+
       - name: Cache pip
         uses: actions/cache@v1
         with:
@@ -36,6 +40,7 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
           restore-keys: |
             ${{ runner.os }}-pip-
+
       - name: Cache checked links
         uses: actions/cache@v2
         with:
@@ -43,13 +48,31 @@ jobs:
           key: ${{ runner.os }}-linkcheck-${{ hashFiles('**/.md') }}-md-links
           restore-keys: |
             ${{ runner.os }}-linkcheck-
+
       - name: Upgrade packaging dependencies
         run: |
           pip install --upgrade pip setuptools wheel jupyter-packaging~=0.10 --user
+
       - name: Install Dependencies
         run: |
           pip install .
+
+      - name: Configure Version Spec
+        id: version-spec
+        if: ${{ matrix.group == 'check_release' }}
+        run: |
+          set -eux
+          version=$(python setup.py --version)
+          if [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            version_spec=patch
+          else
+            version_spec=build
+          fi
+          echo "::set-output name=spec::${version_spec}"
+
       - name: Check Release
         uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v1
+        env:
+          RH_VERSION_SPEC: ${{ steps.version-spec.outputs.spec }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -38,6 +38,7 @@ Make sure the `dist/` folder is empty.
 1. If the JupyterLab extension has changed, make sure to bump the version number in `./packages/jupyterlab-preview/package.json`
 2. If the Voilà front-end JavaScript has changed, make sure to bump the version number in `./packages/voila/package.json`
 3. Bump the version:
+   - `python -m pip install bump2version jupyter-releaser`
    - For a patch release: `python scripts/bump-version patch`
    - For a build release: `python scripts/bump-version build`
 4. `python -m build`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -38,8 +38,8 @@ Make sure the `dist/` folder is empty.
 1. If the JupyterLab extension has changed, make sure to bump the version number in `./packages/jupyterlab-preview/package.json`
 2. If the Voilà front-end JavaScript has changed, make sure to bump the version number in `./packages/voila/package.json`
 3. Bump the version:
-   - `pip install tbump@git+git://github.com/dmerejkowsky/tbump.git@03988d5d2267ddd4a33b3c4196b05b7f24f0a0a4`
-   - `tbump x.y.z`
+   - For a patch release: `python scripts/bump-version patch`
+   - For a build release: `python scripts/bump-version build`
 4. `python -m build`
 5. Double check the size of the bundles in the `dist/` folder
 6. Make sure the JupyterLab extension is correctly bundled in source distribution

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,24 @@ Soon, the recommended way to make a release will be to use [`jupyter_releaser`](
 
 For now releases are still done manually (see section below).
 
+## Bumping versions
+
+`voila` follows a similar bump strategy as in JupyterLab:
+
+https://github.com/jupyterlab/jupyterlab/blob/master/RELEASE.md#bump-version
+
+To manually bump the version, run:
+
+```bash
+# install the dependencies
+python -m pip install -e ".[test,dev]"
+
+# bump the version
+python scripts/bump-version.py <spec>
+```
+
+Where `<spec>` can be one of the following: `patch`, `minor`, `major`, `release`.
+
 ## Releasing on conda-forge
 
 1. Open a new PR on https://github.com/conda-forge/voila-feedstock to update the `version` and the `sha256` hash (see [example](https://github.com/conda-forge/voila-feedstock/pull/23/files))

--- a/packages/voila/package.json
+++ b/packages/voila/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@voila-dashboards/voila",
   "private": true,
-  "version": "1.0.0",
+  "version": "0.2.11",
   "description": "The Voilà Frontend",
   "author": "Voilà contributors",
   "license": "BSD-3-Clause",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,20 +16,6 @@ factory = "jupyter_packaging.npm_builder"
 build_cmd = "build:prod"
 npm = ["jlpm"]
 
-[tool.tbump.version]
-current = "0.2.11"
-regex = '''
-  (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
-  ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?
-'''
-
-[tool.tbump.git]
-message_template = "Release {new_version}"
-tag_template = "{new_version}"
-
-[[tool.tbump.file]]
-src = "voila/_version.py"
-
 [tool.jupyter-releaser.hooks]
 before-build-npm = ["python -m pip install jupyterlab~=3.0", "jlpm"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ before-build-npm = ["python -m pip install jupyterlab~=3.0", "jlpm"]
 before-build-python = ["python -m pip install bump2version"]
 
 [tool.jupyter-releaser.options]
-version-cmd = "python scripts/bump-version.py"
+version-cmd = "python scripts/bump-version.py --force"
 
 [tool.check-manifest]
 ignore = [".binder/**", "docs/**", "notebooks/**", "packages/**", "share/**/*.js", "share/**/*.woff", "*.json", "*.gif", "yarn.lock", "environment.yml", "readthedocs.yml", ".*", "lint-staged.config.js", "scripts/**", "voila/labextension/**", "voila/static/**", "tests/**", "ui-tests/**"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ npm = ["jlpm"]
 skip = ["check-links"]
 
 [tool.jupyter-releaser.hooks]
-before-bump-version = ["python -m pip install bump2version"]
+before-bump-version = ["python -m pip install bump2version jupyterlab~=3.0"]
 before-build-npm = ["python -m pip install jupyterlab~=3.0", "jlpm"]
 
 [tool.jupyter-releaser.options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,15 @@ factory = "jupyter_packaging.npm_builder"
 build_cmd = "build:prod"
 npm = ["jlpm"]
 
+[tool.jupyter-releaser]
+skip = ["check-links"]
+
 [tool.jupyter-releaser.hooks]
 before-build-npm = ["python -m pip install jupyterlab~=3.0", "jlpm"]
+before-build-python = ["python -m pip install bump2version"]
+
+[tool.jupyter-releaser.options]
+version-cmd = "python scripts/bump-version.py"
 
 [tool.check-manifest]
 ignore = [".binder/**", "docs/**", "notebooks/**", "packages/**", "share/**/*.js", "share/**/*.woff", "*.json", "*.gif", "yarn.lock", "environment.yml", "readthedocs.yml", ".*", "lint-staged.config.js", "scripts/**", "voila/labextension/**", "voila/static/**", "tests/**", "ui-tests/**"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ skip = ["check-links"]
 
 [tool.jupyter-releaser.hooks]
 before-bump-version = ["python -m pip install bump2version jupyterlab~=3.0"]
-before-build-npm = ["python -m pip install jupyterlab~=3.0", "jlpm"]
+before-build-npm = ["python -m pip install jupyterlab~=3.0"]
 
 [tool.jupyter-releaser.options]
 version-cmd = "python scripts/bump-version.py --force"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ skip = ["check-links"]
 
 [tool.jupyter-releaser.hooks]
 before-bump-version = ["python -m pip install bump2version jupyterlab~=3.0"]
-before-build-npm = ["python -m pip install jupyterlab~=3.0"]
+before-build-npm = ["python -m pip install jupyterlab~=3.0", "jlpm", "jlpm build:prod"]
 
 [tool.jupyter-releaser.options]
 version-cmd = "python scripts/bump-version.py --force"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,4 +34,4 @@ src = "voila/_version.py"
 before-build-npm = ["python -m pip install jupyterlab~=3.0", "jlpm"]
 
 [tool.check-manifest]
-ignore = [".binder/**", "docs/**", "notebooks/**", "packages/**", "share/**/*.js", "share/**/*.woff", "*.json", "*.gif", "yarn.lock", "environment.yml", "readthedocs.yml", ".*", "lint-staged.config.js", "voila/labextension/**", "voila/static/**", "tests/**", "ui-tests/**"]
+ignore = [".binder/**", "docs/**", "notebooks/**", "packages/**", "share/**/*.js", "share/**/*.woff", "*.json", "*.gif", "yarn.lock", "environment.yml", "readthedocs.yml", ".*", "lint-staged.config.js", "scripts/**", "voila/labextension/**", "voila/static/**", "tests/**", "ui-tests/**"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ npm = ["jlpm"]
 skip = ["check-links"]
 
 [tool.jupyter-releaser.hooks]
+before-bump-version = ["python -m pip install bump2version"]
 before-build-npm = ["python -m pip install jupyterlab~=3.0", "jlpm"]
-before-build-python = ["python -m pip install bump2version"]
 
 [tool.jupyter-releaser.options]
 version-cmd = "python scripts/bump-version.py --force"

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -36,7 +36,7 @@ def patch(force=False):
     # Version the changed
     cmd = "jlpm run lerna version patch --no-push --force-publish --no-git-tag-version"
     if force:
-      cmd += ' --yes'
+        cmd += " --yes"
     run(cmd)
 
 

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -96,9 +96,9 @@ def update(spec, force=False):
 
 
 @click.command()
+@click.option("--force", default=False, is_flag=True)
 @click.argument("spec", nargs=1)
-@click.option("--force", default=False)
-def bump(spec, force):
+def bump(force, spec):
     if spec == "patch":
         patch(force)
         return

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -1,1 +1,31 @@
-from jupyter_releaser import run
+import click
+from jupyter_releaser.util import run
+
+
+def get_python_version():
+    """Return the version of the voila Python package"""
+    import voila
+
+    return voila.__version__
+
+
+@click.command()
+@click.option("--spec", default="patch", help="Number of greetings.")
+def bump(spec):
+    python_version = get_python_version()
+    print(python_version)
+    if "a" in python_version or "b" in python_version or "rc" in python_version:
+        raise Exception("Can only make a patch release from a final version")
+
+    run("bumpversion patch")
+    # switches to alpha
+    run("bumpversion release --allow-dirty")
+    # switches to beta
+    run("bumpversion release --allow-dirty")
+    # switches to rc.
+    run("bumpversion release --allow-dirty")
+    # switches to final.
+
+
+if __name__ == "__main__":
+    bump()

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -17,13 +17,13 @@ def bump(spec):
     if "a" in python_version or "b" in python_version or "rc" in python_version:
         raise Exception("Can only make a patch release from a final version")
 
-    run("bumpversion patch")
+    run("bumpversion patch", quiet=True)
     # switches to alpha
-    run("bumpversion release --allow-dirty")
+    run("bumpversion release --allow-dirty", quiet=True)
     # switches to beta
-    run("bumpversion release --allow-dirty")
+    run("bumpversion release --allow-dirty", quiet=True)
     # switches to rc.
-    run("bumpversion release --allow-dirty")
+    run("bumpversion release --allow-dirty", quiet=True)
     # switches to final.
 
 

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -1,5 +1,15 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.import click
+
+# Heavily inspired by:
+# - https://github.com/jupyterlab/jupyterlab/blob/master/buildutils/src/bumpversion.ts
+# - https://github.com/jupyterlab/retrolab/blob/main/buildutils/src/release-bump.ts
+
 import click
 from jupyter_releaser.util import run
+
+
+OPTIONS = ["major", "minor", "release", "build"]
 
 
 def get_python_version():
@@ -24,11 +34,70 @@ def patch():
     # switches to final.
 
 
+def update(spec, force=False):
+    prev = get_python_version()
+
+    # Make sure we have a valid version spec.
+    if spec not in OPTIONS:
+        raise Exception(f"Version spec must be one of: {OPTIONS}")
+
+    is_final = "a" not in prev and "b" not in prev and "c" not in prev
+
+    if is_final and spec == "release":
+        raise Exception('Use "major" or "minor" to switch back to alpha release')
+
+    if is_final and spec == "build":
+        raise Exception("Cannot increment a build on a final release")
+
+    # TODO: check git status
+
+    # If this is a major release during the alpha cycle, bump
+    # just the Python version.
+    if "a" in prev and spec == "major":
+        run(f"bumpversion {spec}")
+        return
+
+    # Determine the version spec to use for lerna.
+    lerna_version = "preminor"
+    if spec == "build":
+        lerna_version = "prerelease"
+    # a -> b
+    elif spec == "release" and "a" in prev:
+        lerna_version = "prerelease --preid=beta"
+    # b -> rc
+    elif spec == "release" and "b" in prev:
+        lerna_version = "prerelease --preid=rc"
+    # rc -> final
+    elif spec == "release" and "c" in prev:
+        lerna_version = "patch"
+    if lerna_version == "preminor":
+        lerna_version += " --preid=alpha"
+
+    cmd = f"jlpm run lerna version --force-publish --no-push --no-git-tag-version {lerna_version}"
+    if force:
+        cmd += " --yes"
+
+    # For a preminor release, we bump 10 minor versions so that we do
+    # not conflict with versions during minor releases of the top level package.
+    if lerna_version == "preminor":
+        for i in range(10):
+            run(cmd)
+    else:
+        run(cmd)
+
+    # Bump the version.
+    run(f"bumpversion {spec} --allow-dirty")
+
+
 @click.command()
-@click.argument("spec", nargs=1, help="The spec")
-def bump(spec):
+@click.argument("spec", nargs=1)
+@click.option("--force", default=False)
+def bump(spec, force):
     if spec == "patch":
         patch()
+        return
+
+    update(spec, force)
 
 
 if __name__ == "__main__":

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -55,8 +55,6 @@ def update(spec, force=False):
     if is_final and spec == "build":
         raise Exception("Cannot increment a build on a final release")
 
-    # TODO: check git status
-
     # If this is a major release during the alpha cycle, bump
     # just the Python version.
     if "a" in prev and spec == "major":
@@ -99,6 +97,10 @@ def update(spec, force=False):
 @click.option("--force", default=False, is_flag=True)
 @click.argument("spec", nargs=1)
 def bump(force, spec):
+    status = run("git status --porcelain").strip()
+    if len(status) > 0:
+        raise Exception("Must be in a clean git state with no untracked files")
+
     if spec == "patch":
         patch(force)
         return

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -9,11 +9,8 @@ def get_python_version():
     return voila.__version__
 
 
-@click.command()
-@click.option("--spec", default="patch", help="Number of greetings.")
-def bump(spec):
+def patch():
     python_version = get_python_version()
-    print(python_version)
     if "a" in python_version or "b" in python_version or "rc" in python_version:
         raise Exception("Can only make a patch release from a final version")
 
@@ -25,6 +22,13 @@ def bump(spec):
     # switches to rc.
     run("bumpversion release --allow-dirty", quiet=True)
     # switches to final.
+
+
+@click.command()
+@click.argument("spec", nargs=1, help="The spec")
+def bump(spec):
+    if spec == "patch":
+        patch()
 
 
 if __name__ == "__main__":

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -19,7 +19,7 @@ def get_python_version():
     return voila.__version__
 
 
-def patch():
+def patch(force=False):
     python_version = get_python_version()
     if "a" in python_version or "b" in python_version or "rc" in python_version:
         raise Exception("Can only make a patch release from a final version")
@@ -32,6 +32,12 @@ def patch():
     # switches to rc.
     run("bumpversion release --allow-dirty", quiet=True)
     # switches to final.
+
+    # Version the changed
+    cmd = "jlpm run lerna version patch --no-push --force-publish --no-git-tag-version"
+    if force:
+      cmd += ' --yes'
+    run(cmd)
 
 
 def update(spec, force=False):
@@ -94,7 +100,7 @@ def update(spec, force=False):
 @click.option("--force", default=False)
 def bump(spec, force):
     if spec == "patch":
-        patch()
+        patch(force)
         return
 
     update(spec, force)

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -1,0 +1,1 @@
+from jupyter_releaser import run

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,9 @@ install_requires =
     nbconvert>=6.0.0,<7
 
 [options.extras_require]
+dev =
+    jupyter_releaser~=0.6
+
 test =
     ipywidgets
     mock

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,8 @@ install_requires =
 
 [options.extras_require]
 dev =
+    black
+    bump2version
     jupyter_releaser~=0.6
 
 test =

--- a/voila/_version.py
+++ b/voila/_version.py
@@ -12,23 +12,22 @@
 
 from collections import namedtuple
 
-VersionInfo = namedtuple('VersionInfo', [
-    'major',
-    'minor',
-    'micro',
-    'releaselevel',
-    'serial'
-])
+VersionInfo = namedtuple(
+    "VersionInfo", ["major", "minor", "micro", "releaselevel", "serial"]
+)
 
 # DO NOT EDIT THIS DIRECTLY!  It is managed by bumpversion
-version_info = VersionInfo(0, 2, 11, 'final', 0)
+version_info = VersionInfo(0, 2, 11, "final", 0)
 
-_specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc', 'final': ''}
+_specifier_ = {"alpha": "a", "beta": "b", "candidate": "rc", "final": ""}
 
-__version__ = '{}.{}.{}{}'.format(
+__version__ = "{}.{}.{}{}".format(
     version_info.major,
     version_info.minor,
     version_info.micro,
-    (''
-     if version_info.releaselevel == 'final'
-else _specifier_[version_info.releaselevel] + str(version_info.serial)))
+    (
+        ""
+        if version_info.releaselevel == "final"
+        else _specifier_[version_info.releaselevel] + str(version_info.serial)
+    ),
+)

--- a/voila/_version.py
+++ b/voila/_version.py
@@ -7,15 +7,28 @@
 # The full license is in the file LICENSE, distributed with this software.  #
 #############################################################################
 
-import re
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
 
-# Version string must appear intact for tbump versioning
-__version__ = '0.2.11'
+from collections import namedtuple
 
-# Build up version_info tuple for backwards compatibility
-pattern = r'(?P<major>\d+).(?P<minor>\d+).(?P<patch>\d+)(?P<rest>.*)'
-match = re.match(pattern, __version__)
-parts = [int(match[part]) for part in ['major', 'minor', 'patch']]
-if match['rest']:
-    parts.append(match['rest'])
-version_info = tuple(parts)
+VersionInfo = namedtuple('VersionInfo', [
+    'major',
+    'minor',
+    'micro',
+    'releaselevel',
+    'serial'
+])
+
+# DO NOT EDIT THIS DIRECTLY!  It is managed by bumpversion
+version_info = VersionInfo(0, 2, 11, 'final', 0)
+
+_specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc', 'final': ''}
+
+__version__ = '{}.{}.{}{}'.format(
+    version_info.major,
+    version_info.minor,
+    version_info.micro,
+    (''
+     if version_info.releaselevel == 'final'
+else _specifier_[version_info.releaselevel] + str(version_info.serial)))


### PR DESCRIPTION
<!--
Thanks for contributing to Voilà!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/voila-dashboards/voila/blob/master/CONTRIBUTING.md
-->

## References

So we can have a single command to bump the version of both the Python packages and the npm packages.

Instead of doing it manually. This way it will also be possible to use the releaser (#805).

<!-- Note issue numbers this pull request addresses. -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Add a new script to bump the version.

### TODO

- [x] Add a script to bump the Python and JS versions
- [x] Bump Python version with `bump2version`
- [x] Align the `@voial-dashboards/voila` version of the JS frontend with the Python version
- [x] Update RELEASE.md with the version bump process (build, patch, major, minor)

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to Voilà public APIs. -->
