### PR TITLE
Make `INotebookTracker` optional

### DIFF
--- a/packages/jupyterlab-preview/src/index.ts
+++ b/packages/jupyterlab-preview/src/index.ts
@@ -85,12 +85,17 @@ class VoilaRenderButton
 const extension: JupyterFrontEndPlugin<IVoilaPreviewTracker> = {
   id: '@voila-dashboards/jupyterlab-preview:plugin',
   autoStart: true,
-  requires: [INotebookTracker],
-  optional: [ICommandPalette, ILayoutRestorer, IMainMenu, ISettingRegistry],
+  optional: [
+    INotebookTracker,
+    ICommandPalette,
+    ILayoutRestorer,
+    IMainMenu,
+    ISettingRegistry
+  ],
   provides: IVoilaPreviewTracker,
   activate: (
     app: JupyterFrontEnd,
-    notebooks: INotebookTracker,
+    notebooks: INotebookTracker | null,
     palette: ICommandPalette | null,
     restorer: ILayoutRestorer | null,
     menu: IMainMenu | null,
@@ -114,7 +119,7 @@ const extension: JupyterFrontEndPlugin<IVoilaPreviewTracker> = {
     }
 
     function getCurrent(args: ReadonlyPartialJSONObject): NotebookPanel | null {
-      const widget = notebooks.currentWidget;
+      const widget = notebooks?.currentWidget ?? null;
       const activate = args['activate'] !== false;
 
       if (activate && widget) {
@@ -126,8 +131,8 @@ const extension: JupyterFrontEndPlugin<IVoilaPreviewTracker> = {
 
     function isEnabled(): boolean {
       return (
-        notebooks.currentWidget !== null &&
-        notebooks.currentWidget === app.shell.currentWidget
+        notebooks?.currentWidget !== null &&
+        notebooks?.currentWidget === app.shell.currentWidget
       );
     }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Voilà!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/voila-dashboards/voila/blob/master/CONTRIBUTING.md
-->

## References

This should help fix some dev tools console errors as seen in #846 

And make it possible to still use the `Voila-preview` factory in case the notebook tracker plugin is not available (for example in a custom lab distribution):

![image](https://user-images.githubusercontent.com/591645/133386353-60244b36-7024-4ee7-bd58-86606488e84c.png)


<!-- Note issue numbers this pull request addresses. -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Make a dependency optional for the lab extension.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to Voilà public APIs. -->
