### PR TITLE
 Use `sendBeacon` to send kernel shutdown request.

### DIFF
--- a/share/jupyter/voila/templates/base/static/main.js
+++ b/share/jupyter/voila/templates/base/static/main.js
@@ -52,10 +52,12 @@ require([window.voila_js_url || 'static/voila'], function(voila) {
             // it seems if we attach this to early, it will not be called
             const matches = document.cookie.match('\\b_xsrf=([^;]*)\\b');
             const xsrfToken = (matches && matches[1]) || '';
+            const  configData = JSON.parse(document.getElementById('jupyter-config-data').textContent);
+            const baseUrl = configData.baseUrl;
             window.addEventListener('beforeunload', function (e) {
                 const data = new FormData();
                 data.append("_xsrf", xsrfToken);
-                window.navigator.sendBeacon(`/voila/api/shutdown/${kernel.id}`, data);
+                window.navigator.sendBeacon(`${baseUrl}voila/api/shutdown/${kernel.id}`, data);
                 kernel.dispose();
             });
             await widgetManager.build_widgets();

--- a/share/jupyter/voila/templates/base/static/main.js
+++ b/share/jupyter/voila/templates/base/static/main.js
@@ -52,7 +52,7 @@ require([window.voila_js_url || 'static/voila'], function(voila) {
             // it seems if we attach this to early, it will not be called
             const matches = document.cookie.match('\\b_xsrf=([^;]*)\\b');
             const xsrfToken = (matches && matches[1]) || '';
-            const  configData = JSON.parse(document.getElementById('jupyter-config-data').textContent);
+            const configData = JSON.parse(document.getElementById('jupyter-config-data').textContent);
             const baseUrl = configData.baseUrl;
             window.addEventListener('beforeunload', function (e) {
                 const data = new FormData();

--- a/share/jupyter/voila/templates/base/static/main.js
+++ b/share/jupyter/voila/templates/base/static/main.js
@@ -53,10 +53,9 @@ require([window.voila_js_url || 'static/voila'], function(voila) {
             const matches = document.cookie.match('\\b_xsrf=([^;]*)\\b');
             const xsrfToken = (matches && matches[1]) || '';
             window.addEventListener('beforeunload', function (e) {
-                const xhttp = new XMLHttpRequest();
-                xhttp.open("DELETE", `/api/kernels/${kernel.id}`, true);
-                xhttp.setRequestHeader('X-XSRFToken', xsrfToken);
-                xhttp.send();
+                const data = new FormData();
+                data.append("_xsrf", xsrfToken);
+                window.navigator.sendBeacon(`/voila/api/shutdown/${kernel.id}`, data);
                 kernel.dispose();
             });
             await widgetManager.build_widgets();

--- a/share/jupyter/voila/templates/base/static/main.js
+++ b/share/jupyter/voila/templates/base/static/main.js
@@ -54,7 +54,7 @@ require([window.voila_js_url || 'static/voila'], function(voila) {
             const xsrfToken = (matches && matches[1]) || '';
             window.addEventListener('beforeunload', function (e) {
                 const xhttp = new XMLHttpRequest();
-                xhttp.open("DELETE", `/api/kernels/${kernel.id}`, false);
+                xhttp.open("DELETE", `/api/kernels/${kernel.id}`, true);
                 xhttp.setRequestHeader('X-XSRFToken', xsrfToken);
                 xhttp.send();
                 kernel.dispose();

--- a/tests/app/shutdown_kernel_test.py
+++ b/tests/app/shutdown_kernel_test.py
@@ -1,0 +1,12 @@
+import re
+
+
+async def test_shutdown_handler(http_server_client, base_url):
+    response = await http_server_client.fetch(base_url)
+    html_text = response.body.decode('utf-8')
+    pattern = r"""kernelId": ["']([0-9a-zA-Z-]+)["']"""
+    groups = re.findall(pattern, html_text)
+    kernel_id = groups[0]
+    shutdown_url = f'{base_url}voila/api/shutdown/{kernel_id}'
+    shutdown_response = await http_server_client.fetch(shutdown_url, method='POST', body=b'')
+    assert shutdown_response.code == 204

--- a/voila/app.py
+++ b/voila/app.py
@@ -59,6 +59,7 @@ from .static_file_handler import MultiStaticFileHandler, TemplateStaticFileHandl
 from .configuration import VoilaConfiguration
 from .execute import VoilaExecutor
 from .exporter import VoilaExporter
+from .shutdown_kernel_handler import VoilaShutdownKernelHandler
 
 _kernel_id_regex = r"(?P<kernel_id>\w+-\w+-\w+-\w+-\w+)"
 
@@ -470,6 +471,7 @@ class Voila(Application):
                     'default_filename': 'index.html'
                 },
             ),
+            (url_path_join(self.server_url, r'/voila/api/shutdown/(.*)'), VoilaShutdownKernelHandler)
         ])
 
         # Serving notebook extensions

--- a/voila/server_extension.py
+++ b/voila/server_extension.py
@@ -21,6 +21,7 @@ from .treehandler import VoilaTreeHandler
 from .static_file_handler import MultiStaticFileHandler, TemplateStaticFileHandler, WhiteListFileHandler
 from .configuration import VoilaConfiguration
 from .utils import get_server_root_dir
+from .shutdown_kernel_handler import VoilaShutdownKernelHandler
 
 
 def _jupyter_server_extension_paths():
@@ -67,6 +68,7 @@ def _load_jupyter_server_extension(server_app):
         (url_path_join(base_url, '/voila/tree' + path_regex), VoilaTreeHandler, tree_handler_conf),
         (url_path_join(base_url, '/voila/templates/(.*)'), TemplateStaticFileHandler),
         (url_path_join(base_url, '/voila/static/(.*)'), MultiStaticFileHandler, {'paths': static_paths}),
+        (url_path_join(base_url, r'/voila/api/shutdown/(.*)'), VoilaShutdownKernelHandler),
         (
             url_path_join(base_url, r'/voila/files/(.*)'),
             WhiteListFileHandler,

--- a/voila/shutdown_kernel_handler.py
+++ b/voila/shutdown_kernel_handler.py
@@ -3,7 +3,7 @@ from jupyter_server.base.handlers import APIHandler
 
 
 class VoilaShutdownKernelHandler(APIHandler):
-    """ Handler to shutdown kernel on page's `beforeunload` event.
+    """ Handler to shut down kernel on page's `beforeunload` event.
     """
 
     @tornado.web.authenticated

--- a/voila/shutdown_kernel_handler.py
+++ b/voila/shutdown_kernel_handler.py
@@ -1,5 +1,6 @@
 import tornado
 from jupyter_server.base.handlers import APIHandler
+from nbclient.util import ensure_async
 
 
 class VoilaShutdownKernelHandler(APIHandler):
@@ -8,6 +9,6 @@ class VoilaShutdownKernelHandler(APIHandler):
 
     @tornado.web.authenticated
     async def post(self, kernel_id):
-        await self.kernel_manager.shutdown_kernel(kernel_id)
+        await ensure_async(self.kernel_manager.shutdown_kernel(kernel_id))
         self.set_status(204)
         self.finish()

--- a/voila/shutdown_kernel_handler.py
+++ b/voila/shutdown_kernel_handler.py
@@ -1,0 +1,13 @@
+import tornado
+from jupyter_server.base.handlers import APIHandler
+
+
+class VoilaShutdownKernelHandler(APIHandler):
+    """ Handler to shutdown kernel on page's `beforeunload` event.
+    """
+
+    @tornado.web.authenticated
+    async def post(self, kernel_id):
+        await self.kernel_manager.shutdown_kernel(kernel_id)
+        self.set_status(204)
+        self.finish()


### PR DESCRIPTION
## References

 Support for synchronous use of `XMLHTTPRequest()` during page unloads is removed from Chrome (https://www.chromestatus.com/feature/4664843055398912). 

## Code changes
Use `sendBeacon` to send kernel shutdown request on `beforeunload` event
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
N/A
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
N/A
<!-- Describe any backwards-incompatible changes to Voilà public APIs. -->
