### PR TITLE
Update to nbconvert 6.2

### DIFF
--- a/share/jupyter/voila/templates/base/jupyter_widgets.html.j2
+++ b/share/jupyter/voila/templates/base/jupyter_widgets.html.j2
@@ -1,2 +1,2 @@
-{%- macro jupyter_widgets(widgets_cdn_url, html_manager_semver_range) -%}
+{%- macro jupyter_widgets(widgets_cdn_url, html_manager_semver_range, widget_renderer_url='') -%}
 {%- endmacro %}


### PR DESCRIPTION
Nbconvert 6.2 adds an argument to the `jupyter_widgets` macro.

Overriding this in voilà with the old number of arguments breaks calling it from the base nbconvert templates with the higher number of args.