### PR TITLE
Add support  for query variables in preheat kernel mode

### DIFF
--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -313,24 +313,24 @@ There is also the ``MappingKernelManager.cull_busy`` and ``MappingKernelManager.
 
 For more information about these options, check out the `Jupyter Server <https://jupyter-server.readthedocs.io/en/latest/other/full-config.html#options>`_ documentation.
 
-Pre-heat kernels
+Preheat kernels
 =================
 
-Since Voilà needs to start a new jupyter kernel and execute the requested notebook in this kernel for every connection, this would lead to a long waiting time before the widgets can be displayed in browser. 
-To reduce this waiting time, especially for the heavy notebooks, user can use the pre-heating kernel option of Voilà, this option will enable two features:
+Since Voilà needs to start a new jupyter kernel and execute the requested notebook in this kernel for every connection, this would lead to a long waiting time before the widgets can be displayed in the browser. 
+To reduce this waiting time, especially for the heavy notebooks, users can activate the preheating kernel option of Voilà, this option will enable two features:
 
-- A pool of kernels is started for each notebook and kept in standby, then the notebook is executed in every kernel of its pool. When a new client requests a kernel, the pre-heated kernel in this pool is used and another kernel is started asynchronously to refill the pool.
-- The HTML version of notebook is rendered in each pre-heated kernel and stored, when a client connects to Voila, under some conditions, the cached HTML is served instead of re-rendering the notebook.
+- A pool of kernels is started for each notebook and kept in standby, then the notebook is executed in every kernel of its pool. When a new client requests a kernel, the preheated kernel in this pool is used and another kernel is started asynchronously to refill the pool.
+- The HTML version of the notebook is rendered in each preheated kernel and stored, when a client connects to Voila, under some conditions, the cached HTML is served instead of re-rendering the notebook.
 
-The pre-heat kernel option works with any kernel manager, it is deactivated by default, re-activate it by setting `preheat_kernel = True`.  For example, with this command, for each notebook Voilà started with, a pool of 5 kernels is created and will be used for new connections.
+The preheating kernel option works with any kernel manager, it is deactivated by default, re-activate it by setting `preheat_kernel = True`.  For example, with this command, for each notebook Voilà started with, a pool of 5 kernels is created and will be used for new connections.
 
 .. code-block:: bash
 
     voila --preheat_kernel=True --pool_size=5
 
-If the pool size does not match the user's requirements, or some notebooks need to use environment variables..., additional settings are needed.  The easiest way to change these settings is to provide a file named `voila.json` in the same folder containing the notebooks. Settings for pre-heat kernel ( list of notebooks does not need pre-heated kernels, number of kernels in pool, refilling delay, environment variables for starting kernel...) can be set under the `VoilaKernelManager` class name.
+If the pool size does not match the user's requirements, or some notebooks need to use environment variables..., additional settings are needed.  The easiest way to change these settings is to provide a file named `voila.json` in the same folder containing the notebooks. Settings for preheating kernel ( list of notebooks does not need preheated kernels, number of kernels in pool, refilling delay, environment variables for starting kernel...) can be set under the `VoilaKernelManager` class name.
 
-Here is an example of settings with explanations for pre-heat kernel option. 
+Here is an example of settings with explanations for preheating kernel option. 
 
 .. code-block:: python
 
@@ -374,13 +374,59 @@ Here is an example of settings with explanations for pre-heat kernel option.
       }
    }
 
-Notebook HTML will be pre-rendered with template and theme defined in VoilaConfiguration or in notebook metadata. The pre-heated kernel and cached HTML are used if these conditions are matched:
+Notebook HTML will be pre-rendered with template and theme defined in VoilaConfiguration or notebook metadata. The preheated kernel and cached HTML are used if these conditions are matched:
 
-- There is an available pre-heated kernel in the kernel pool.
+- There is an available preheated kernel in the kernel pool.
 - If user overrides the template/theme with query string, it must match the template/theme used to pre-render the notebook.
-- There is no other query strings than `voila-theme` and `voila-template`.
 
 If the kernel pool is empty or the request does not match these conditions, Voila will fail back to start a normal kernel and render the notebook as usual.
+
+Partially pre-render notebook
+------------------------------
+
+To benefit the acceleration of preheating kernel mode, the notebooks need to be pre-rendered before users actually connect to Voilà. But in many real-world cases, the notebook requires some user-specific data to render correctly the widgets, which makes pre-rendering become impossible. To overcome this limit, Voilà offers a feature to treat the most used method for providing user data: the URL `query string`.
+
+In normal mode, Voilà users can get the `query string` at run time through the ``QUERY_STRING`` environment variable:
+
+.. code-block:: python
+
+   import os
+   query_string = os.getenv('QUERY_STRING') 
+
+In preheating kernel mode, users can just replace the ``os.getenv`` call with the helper ``get_user_query`` from ``voila.utils``
+
+.. code-block:: python
+
+   from voila.utils import get_user_query
+   query_string = await get_user_query()
+
+or if you use the raw mode of ``xeus-python``:
+
+.. code-block:: python
+
+   query_string = asyncio.get_event_loop().run_until_complete(get_user_query())
+
+``get_user_query`` will pause the execution of notebook in the preheated kernel at its cell and wait for an actual user connects to Voilà, then ``get_user_query`` will return the URL `query string` and continue the execution of remaining cells. 
+
+If Voilà is not started at the default IP address (`127.0.0.1`) or the default port (`8866`), users need to provide these values through the environment variables ``VOILA_APP_IP`` and ``VOILA_APP_PORT``. The easiest way is to set these variables in `voila.json` configuration file, for example:
+
+.. code-block:: python
+
+   # voila.json
+   {
+      ...
+      "VoilaKernelManager": {
+         "kernel_pools_config": { 
+            "foo.ipynb": {
+               "kernel_env_variables": { 
+                  "VOILA_APP_IP": "192.168.1.1",
+                  "VOILA_APP_PORT": "6789"
+               }
+            }
+         },
+      ...
+      }
+   }
 
 Hiding output and code cells based on cell tags
 ===============================================

--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -398,17 +398,11 @@ In preheating kernel mode, users can just replace the ``os.getenv`` call with th
 .. code-block:: python
 
    from voila.utils import get_user_query
-   query_string = await get_user_query()
-
-or if you use the raw mode of ``xeus-python``:
-
-.. code-block:: python
-
-   query_string = asyncio.get_event_loop().run_until_complete(get_user_query())
+   query_string = get_user_query()
 
 ``get_user_query`` will pause the execution of notebook in the preheated kernel at its cell and wait for an actual user connects to Voilà, then ``get_user_query`` will return the URL `query string` and continue the execution of remaining cells. 
 
-If Voilà is not started at the default IP address (`127.0.0.1`) or the default port (`8866`), users need to provide these values through the environment variables ``VOILA_APP_IP`` and ``VOILA_APP_PORT``. The easiest way is to set these variables in `voila.json` configuration file, for example:
+If Voilà websocket handler is not started at the default protocol (`ws`), the default IP address (`127.0.0.1`) or the default port (`8866`), users need to provide these values through the environment variables ``VOILA_APP_PROTOCOL``, ``VOILA_APP_IP`` and ``VOILA_APP_PORT``. The easiest way is to set these variables in `voila.json` configuration file, for example:
 
 .. code-block:: python
 
@@ -420,7 +414,8 @@ If Voilà is not started at the default IP address (`127.0.0.1`) or the default 
             "foo.ipynb": {
                "kernel_env_variables": { 
                   "VOILA_APP_IP": "192.168.1.1",
-                  "VOILA_APP_PORT": "6789"
+                  "VOILA_APP_PORT": "6789",
+                  "VOILA_APP_PROTOCOL": "wss"
                }
             }
          },

--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -384,7 +384,7 @@ If the kernel pool is empty or the request does not match these conditions, Voil
 Partially pre-render notebook
 ------------------------------
 
-To benefit the acceleration of preheating kernel mode, the notebooks need to be pre-rendered before users actually connect to Voilà. But in many real-world cases, the notebook requires some user-specific data to render correctly the widgets, which makes pre-rendering become impossible. To overcome this limit, Voilà offers a feature to treat the most used method for providing user data: the URL `query string`.
+To benefit the acceleration of preheating kernel mode, the notebooks need to be pre-rendered before users actually connect to Voilà. But in many real-world cases, the notebook requires some user-specific data to render correctly the widgets, which makes pre-rendering impossible. To overcome this limit, Voilà offers a feature to treat the most used method for providing user data: the URL `query string`.
 
 In normal mode, Voilà users can get the `query string` at run time through the ``QUERY_STRING`` environment variable:
 
@@ -400,9 +400,9 @@ In preheating kernel mode, users can just replace the ``os.getenv`` call with th
    from voila.utils import get_user_query
    query_string = get_user_query()
 
-``get_user_query`` will pause the execution of notebook in the preheated kernel at its cell and wait for an actual user connects to Voilà, then ``get_user_query`` will return the URL `query string` and continue the execution of remaining cells. 
+``get_user_query`` will pause the execution of the notebook in the preheated kernel at this cell and wait for an actual user to connect to Voilà, then ``get_user_query`` will return the URL `query string` and continue the execution of the remaining cells. 
 
-If Voilà websocket handler is not started at the default protocol (`ws`), the default IP address (`127.0.0.1`) or the default port (`8866`), users need to provide these values through the environment variables ``VOILA_APP_PROTOCOL``, ``VOILA_APP_IP`` and ``VOILA_APP_PORT``. The easiest way is to set these variables in `voila.json` configuration file, for example:
+If the Voilà websocket handler is not started with the default protocol (`ws`), the default IP address (`127.0.0.1`) or the default port (`8866`), users need to provide these values through the environment variables ``VOILA_APP_PROTOCOL``, ``VOILA_APP_IP`` and ``VOILA_APP_PORT``. The easiest way is to set these variables in the `voila.json` configuration file, for example:
 
 .. code-block:: python
 

--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -313,8 +313,8 @@ There is also the ``MappingKernelManager.cull_busy`` and ``MappingKernelManager.
 
 For more information about these options, check out the `Jupyter Server <https://jupyter-server.readthedocs.io/en/latest/other/full-config.html#options>`_ documentation.
 
-Preheat kernels
-=================
+Preheated kernels
+==================
 
 Since Voilà needs to start a new jupyter kernel and execute the requested notebook in this kernel for every connection, this would lead to a long waiting time before the widgets can be displayed in the browser. 
 To reduce this waiting time, especially for the heavy notebooks, users can activate the preheating kernel option of Voilà, this option will enable two features:
@@ -393,14 +393,14 @@ In normal mode, Voilà users can get the `query string` at run time through the 
    import os
    query_string = os.getenv('QUERY_STRING') 
 
-In preheating kernel mode, users can just replace the ``os.getenv`` call with the helper ``get_user_query`` from ``voila.utils``
+In preheating kernel mode, users can just replace the ``os.getenv`` call with the helper ``get_query_string`` from ``voila.utils``
 
 .. code-block:: python
 
-   from voila.utils import get_user_query
-   query_string = get_user_query()
+   from voila.utils import get_query_string
+   query_string = get_query_string()
 
-``get_user_query`` will pause the execution of the notebook in the preheated kernel at this cell and wait for an actual user to connect to Voilà, then ``get_user_query`` will return the URL `query string` and continue the execution of the remaining cells. 
+``get_query_string`` will pause the execution of the notebook in the preheated kernel at this cell and wait for an actual user to connect to Voilà, then ``get_query_string`` will return the URL `query string` and continue the execution of the remaining cells. 
 
 If the Voilà websocket handler is not started with the default protocol (`ws`), the default IP address (`127.0.0.1`) or the default port (`8866`), users need to provide these values through the environment variables ``VOILA_APP_PROTOCOL``, ``VOILA_APP_IP`` and ``VOILA_APP_PORT``. The easiest way is to set these variables in the `voila.json` configuration file, for example:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     jupyter_client>=6.1.3,<8
     nbclient>=0.4.0,<0.6
     nbconvert>=6.0.0,<7
+    websockets>=10.0,<11
 
 [options.extras_require]
 dev =

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     jupyter_client>=6.1.3,<8
     nbclient>=0.4.0,<0.6
     nbconvert>=6.0.0,<7
-    websockets>=10.0,<11
+    websockets>=9.0
 
 [options.extras_require]
 dev =

--- a/tests/app/preheat_activation_test.py
+++ b/tests/app/preheat_activation_test.py
@@ -71,13 +71,13 @@ async def test_render_time_with_multiple_requests(http_server_client,
 async def test_request_with_query(http_server_client, base_url):
     """
     We sent request with query parameter, preheat kernel should
-    be disable is this case.
+    be activated.
     """
     url = f'{base_url}?foo=bar'
     time, _ = await send_request(sc=http_server_client,
                                  url=url,
                                  wait=NOTEBOOK_EXECUTION_TIME + 1)
-    assert time > TIME_THRESHOLD
+    assert time < TIME_THRESHOLD
 
 
 async def test_request_with_theme_parameter(http_server_client, base_url):

--- a/tests/notebooks/preheat/pre_heat.ipynb
+++ b/tests/notebooks/preheat/pre_heat.ipynb
@@ -22,14 +22,6 @@
     "import os\n",
     "os.getenv('foo')"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0e689ec5-708c-4cac-98ba-02b00411e41d",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -48,7 +40,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/voila/app.py
+++ b/voila/app.py
@@ -61,7 +61,7 @@ from .execute import VoilaExecutor
 from .exporter import VoilaExporter
 from .shutdown_kernel_handler import VoilaShutdownKernelHandler
 from .voila_kernel_manager import voila_kernel_manager_factory
-from .query_parameters_handler import QueryParametersHandler
+from .query_parameters_handler import QueryParametersHandler, QueryStringSocketHandler
 
 _kernel_id_regex = r"(?P<kernel_id>\w+-\w+-\w+-\w+-\w+)"
 
@@ -492,6 +492,12 @@ class Voila(Application):
                     {
                         'kernel_manager': self.kernel_manager
                     }
+                )
+            )
+            handlers.append(
+                (
+                    url_path_join(self.server_url, r'/voila/query/%s' % _kernel_id_regex),
+                    QueryStringSocketHandler
                 )
             )
         # Serving notebook extensions

--- a/voila/app.py
+++ b/voila/app.py
@@ -61,7 +61,7 @@ from .execute import VoilaExecutor
 from .exporter import VoilaExporter
 from .shutdown_kernel_handler import VoilaShutdownKernelHandler
 from .voila_kernel_manager import voila_kernel_manager_factory
-from .query_parameters_handler import QueryParametersHandler, QueryStringSocketHandler
+from .query_parameters_handler import QueryStringSocketHandler
 
 _kernel_id_regex = r"(?P<kernel_id>\w+-\w+-\w+-\w+-\w+)"
 
@@ -485,15 +485,6 @@ class Voila(Application):
         ])
 
         if preheat_kernel:
-            handlers.append(
-                (
-                    url_path_join(self.server_url, r'/voila/env/%s\/(?P<var_name>.*)' % _kernel_id_regex),
-                    QueryParametersHandler,
-                    {
-                        'kernel_manager': self.kernel_manager
-                    }
-                )
-            )
             handlers.append(
                 (
                     url_path_join(self.server_url, r'/voila/query/%s' % _kernel_id_regex),

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -20,6 +20,7 @@ from traitlets.traitlets import Bool
 
 from ._version import __version__
 from .notebook_renderer import NotebookRenderer
+from .query_parameters_handler import QueryStringSocketHandler
 
 
 class VoilaHandler(JupyterHandler):
@@ -96,6 +97,8 @@ class VoilaHandler(JupyterHandler):
             render_task, rendered_cache, kernel_id = await self.kernel_manager.get_rendered_notebook(
                     notebook_name=notebook_path,
             )
+            
+            QueryStringSocketHandler.send_updates({'kernel_id': kernel_id, 'payload': str(self.request.query)})
             for name, value in self.request.arguments.items():
                 self.kernel_manager.set_query_params(kernel_id, name, value)
 

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -98,7 +98,7 @@ class VoilaHandler(JupyterHandler):
                     notebook_name=notebook_path,
             )
 
-            QueryStringSocketHandler.send_updates({'kernel_id': kernel_id, 'payload': str(self.request.query)})
+            QueryStringSocketHandler.send_updates({'kernel_id': kernel_id, 'payload': self.request.query})
             # Send rendered cell to frontend
             if len(rendered_cache) > 0:
                 self.write(''.join(rendered_cache))

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -97,11 +97,8 @@ class VoilaHandler(JupyterHandler):
             render_task, rendered_cache, kernel_id = await self.kernel_manager.get_rendered_notebook(
                     notebook_name=notebook_path,
             )
-            
-            QueryStringSocketHandler.send_updates({'kernel_id': kernel_id, 'payload': str(self.request.query)})
-            for name, value in self.request.arguments.items():
-                self.kernel_manager.set_query_params(kernel_id, name, value)
 
+            QueryStringSocketHandler.send_updates({'kernel_id': kernel_id, 'payload': str(self.request.query)})
             # Send rendered cell to frontend
             if len(rendered_cache) > 0:
                 self.write(''.join(rendered_cache))

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -92,9 +92,12 @@ class VoilaHandler(JupyterHandler):
             # Get the pre-rendered content of notebook, the result can be all rendered cells
             # of the notebook or some rendred cells and a generator which can be used by this
             # handler to continue rendering calls.
-            render_task, rendered_cache = await self.kernel_manager.get_rendered_notebook(
+
+            render_task, rendered_cache, kernel_id = await self.kernel_manager.get_rendered_notebook(
                     notebook_name=notebook_path,
             )
+            for name, value in self.request.arguments.items():
+                self.kernel_manager.set_query_params(kernel_id, name, value)
 
             # Send rendered cell to frontend
             if len(rendered_cache) > 0:
@@ -180,10 +183,10 @@ class VoilaHandler(JupyterHandler):
             return False
         if theme is not None and rendered_theme != theme:
             return False
-        args_list = [
-            key for key in request_args if key not in ['voila-template', 'voila-theme']
-        ]
-        if len(args_list) > 0:
-            return False
+        # args_list = [
+        #     key for key in request_args if key not in ['voila-template', 'voila-theme']
+        # ]
+        # if len(args_list) > 0:
+        #     return False
 
         return True

--- a/voila/notebook_renderer.py
+++ b/voila/notebook_renderer.py
@@ -222,16 +222,17 @@ class NotebookRenderer(LoggingConfigurable):
             self.executor.kc.wait_for_ready(timeout=self.executor.startup_timeout)
         )
         self.executor.kc.allow_stdin = False
-        # Set `VOILA_KERNEL_ID` environment variable, this variable help user can 
+        # Set `VOILA_KERNEL_ID` environment variable, this variable help user can
         # identify which kernel the notebook use.
-        await ensure_async(
-            self.executor.kc.execute(
-                f'''import os
-                \nos.environ["{ENV_VARIABLE.VOILA_KERNEL_ID}"]="{kernel_id}"
-                ''',
-                store_history=False,
+        if nb.metadata.kernelspec['language'] == 'python':
+            await ensure_async(
+                self.executor.kc.execute(
+                    f'''import os
+                    \nos.environ["{ENV_VARIABLE.VOILA_KERNEL_ID}"]="{kernel_id}"
+                    ''',
+                    store_history=False,
+                )
             )
-        )
 
         self.kernel_started = True
         return kernel_id

--- a/voila/notebook_renderer.py
+++ b/voila/notebook_renderer.py
@@ -222,7 +222,8 @@ class NotebookRenderer(LoggingConfigurable):
             self.executor.kc.wait_for_ready(timeout=self.executor.startup_timeout)
         )
         self.executor.kc.allow_stdin = False
-        ###
+        # Set `VOILA_KERNEL_ID` environment variable, this variable help user can 
+        # identify which kernel the notebook use.
         await ensure_async(
             self.executor.kc.execute(
                 f'''import os

--- a/voila/notebook_renderer.py
+++ b/voila/notebook_renderer.py
@@ -25,7 +25,7 @@ from traitlets.config.configurable import LoggingConfigurable
 from .execute import VoilaExecutor, strip_code_cell_warnings
 from .exporter import VoilaExporter
 from .paths import collect_template_paths
-
+from .utils import ENV_VARIABLE
 
 class NotebookRenderer(LoggingConfigurable):
     """Render the notebook into HTML string."""
@@ -225,9 +225,7 @@ class NotebookRenderer(LoggingConfigurable):
         await ensure_async(
             self.executor.kc.execute(
                 f'''import os
-                \nos.environ["VOILA_KERNEL_ID"]="{kernel_id}"
-                \nos.environ["VOILA_PREHEAT"]= "{self.voila_configuration.preheat_kernel}"
-                \nos.environ["VOILA_BASE_URL"]="{self.base_url}"
+                \nos.environ["{ENV_VARIABLE.VOILA_KERNEL_ID}"]="{kernel_id}"
                 ''',
                 store_history=False,
             )

--- a/voila/notebook_renderer.py
+++ b/voila/notebook_renderer.py
@@ -27,6 +27,7 @@ from .exporter import VoilaExporter
 from .paths import collect_template_paths
 from .utils import ENV_VARIABLE
 
+
 class NotebookRenderer(LoggingConfigurable):
     """Render the notebook into HTML string."""
 

--- a/voila/notebook_renderer.py
+++ b/voila/notebook_renderer.py
@@ -222,6 +222,17 @@ class NotebookRenderer(LoggingConfigurable):
         )
         self.executor.kc.allow_stdin = False
         ###
+        await ensure_async(
+            self.executor.kc.execute(
+                f'''import os
+                \nos.environ["VOILA_KERNEL_ID"]="{kernel_id}"
+                \nos.environ["VOILA_PREHEAT"]= "{self.voila_configuration.preheat_kernel}"
+                \nos.environ["VOILA_BASE_URL"]="{self.base_url}"
+                ''',
+                store_history=False,
+            )
+        )
+
         self.kernel_started = True
         return kernel_id
 

--- a/voila/query_parameters_handler.py
+++ b/voila/query_parameters_handler.py
@@ -57,5 +57,5 @@ class QueryStringSocketHandler(WebSocketHandler):
                 waiter.write_message(payload)
             except Exception:
                 logging.error("Error sending message", exc_info=True)
-        else:
-            cls._cache[kernel_id] = payload
+
+        cls._cache[kernel_id] = payload

--- a/voila/query_parameters_handler.py
+++ b/voila/query_parameters_handler.py
@@ -1,31 +1,61 @@
 from tornado.websocket import WebSocketHandler
 import logging
+from typing import Dict
 
 
 class QueryStringSocketHandler(WebSocketHandler):
-    waiters = dict()
-    cache = dict()
+    """A websocket handler used to provide the query string
+    assocciated with kernel ids in preheat kernel mode.
 
-    def open(self, kernel_id):
-        QueryStringSocketHandler.waiters[kernel_id] = self
-        if kernel_id in self.cache:
-            self.write_message(self.cache[kernel_id])
+    Class variables
+    ---------------
+    - _waiters : A dictionary which holds the `websocket` connection
+    assocciated with the kernel id.
 
-    def on_close(self):
-        for k_id, waiter in QueryStringSocketHandler.waiters.items():
+    - cache : A dictionary which holds the query string assocciated
+    with the kernel id.
+    """
+    _waiters = dict()
+    _cache = dict()
+
+    def open(self, kernel_id: str) -> None:
+        """Create a new websocket connection, this connection is
+        identified by the kernel id.
+
+        Args:
+            kernel_id (str): Kernel id used by the notebook when it opens
+            the websocket connection.
+        """
+        QueryStringSocketHandler._waiters[kernel_id] = self
+        if kernel_id in self._cache:
+            self.write_message(self._cache[kernel_id])
+
+    def on_close(self) -> None:
+        for k_id, waiter in QueryStringSocketHandler._waiters.items():
             if waiter == self:
                 break
-        del QueryStringSocketHandler.waiters[k_id]
+        del QueryStringSocketHandler._waiters[k_id]
 
     @classmethod
-    def send_updates(cls, msg):
+    def send_updates(cls: 'QueryStringSocketHandler', msg: Dict) -> None:
+        """Class method used to dispath the query string to the waiting
+        notebook. This method is called in `VoilaHandler` when the query
+        string becomes available. 
+        If this method is called before the opening of websocket connection,
+        `msg` is stored in `_cache0` and the message will be dispatched when
+        a notebook with coresponding kernel id is connected.
+
+        Args:
+            - msg (Dict): this dictionary contains the `kernel_id` to identify
+            the waiting notebook and `payload` is the query string.
+        """        
         kernel_id = msg['kernel_id']
         payload = msg['payload']
-        waiter = cls.waiters.get(kernel_id, None)
+        waiter = cls._waiters.get(kernel_id, None)
         if waiter is not None:
             try:
                 waiter.write_message(payload)
             except Exception:
                 logging.error("Error sending message", exc_info=True)
         else:
-            cls.cache[kernel_id] = payload
+            cls._cache[kernel_id] = payload

--- a/voila/query_parameters_handler.py
+++ b/voila/query_parameters_handler.py
@@ -1,50 +1,26 @@
-from tornado.web import RequestHandler
 from tornado.websocket import WebSocketHandler
 import logging
-
-
-class QueryParametersHandler(RequestHandler):
-
-    def initialize(self, kernel_manager=None):
-        self._kernel_manager = None
-        if hasattr(kernel_manager, 'get_query_params'):
-            self._kernel_manager = kernel_manager
-
-    async def get(self, kernel_id: str, var_name: str):
-        if self._kernel_manager is not None:
-            content = self._kernel_manager.get_query_params(kernel_id, var_name)
-            self.finish(content[0])
-        else:
-            self.finish(None)
 
 
 class QueryStringSocketHandler(WebSocketHandler):
     waiters = dict()
     cache = dict()
 
-    def get_compression_options(self):
-        # Non-None enables compression with default options.
-        return {}
-
     def open(self, kernel_id):
-        print("open connection to", kernel_id)
         QueryStringSocketHandler.waiters[kernel_id] = self
         if kernel_id in self.cache:
-            print('sending', self.cache[kernel_id])
             self.write_message(self.cache[kernel_id])
 
     def on_close(self):
         for k_id, waiter in QueryStringSocketHandler.waiters.items():
             if waiter == self:
                 break
-        print('closing', k_id)
         del QueryStringSocketHandler.waiters[k_id]
 
     @classmethod
     def send_updates(cls, msg):
         kernel_id = msg['kernel_id']
         payload = msg['payload']
-        print("sending message to %d waiters", kernel_id)
         waiter = cls.waiters.get(kernel_id, None)
         if waiter is not None:
             try:

--- a/voila/query_parameters_handler.py
+++ b/voila/query_parameters_handler.py
@@ -1,0 +1,16 @@
+from tornado.web import RequestHandler
+
+
+class QueryParametersHandler(RequestHandler):
+
+    def initialize(self, kernel_manager=None):
+        self._kernel_manager = None
+        if hasattr(kernel_manager, 'get_query_params'):
+            self._kernel_manager = kernel_manager
+
+    async def get(self, kernel_id: str, var_name: str):
+        if self._kernel_manager is not None:
+            content = self._kernel_manager.get_query_params(kernel_id, var_name)
+            self.finish(content[0])
+        else:
+            self.finish(None)

--- a/voila/query_parameters_handler.py
+++ b/voila/query_parameters_handler.py
@@ -1,4 +1,6 @@
 from tornado.web import RequestHandler
+from tornado.websocket import WebSocketHandler
+import logging
 
 
 class QueryParametersHandler(RequestHandler):
@@ -14,3 +16,40 @@ class QueryParametersHandler(RequestHandler):
             self.finish(content[0])
         else:
             self.finish(None)
+
+
+class QueryStringSocketHandler(WebSocketHandler):
+    waiters = dict()
+    cache = dict()
+
+    def get_compression_options(self):
+        # Non-None enables compression with default options.
+        return {}
+
+    def open(self, kernel_id):
+        print("open connection to", kernel_id)
+        QueryStringSocketHandler.waiters[kernel_id] = self
+        if kernel_id in self.cache:
+            print('sending', self.cache[kernel_id])
+            self.write_message(self.cache[kernel_id])
+
+    def on_close(self):
+        for k_id, waiter in QueryStringSocketHandler.waiters.items():
+            if waiter == self:
+                break
+        print('closing', k_id)
+        del QueryStringSocketHandler.waiters[k_id]
+
+    @classmethod
+    def send_updates(cls, msg):
+        kernel_id = msg['kernel_id']
+        payload = msg['payload']
+        print("sending message to %d waiters", kernel_id)
+        waiter = cls.waiters.get(kernel_id, None)
+        if waiter is not None:
+            try:
+                waiter.write_message(payload)
+            except Exception:
+                logging.error("Error sending message", exc_info=True)
+        else:
+            cls.cache[kernel_id] = payload

--- a/voila/query_parameters_handler.py
+++ b/voila/query_parameters_handler.py
@@ -40,7 +40,7 @@ class QueryStringSocketHandler(WebSocketHandler):
     def send_updates(cls: 'QueryStringSocketHandler', msg: Dict) -> None:
         """Class method used to dispath the query string to the waiting
         notebook. This method is called in `VoilaHandler` when the query
-        string becomes available. 
+        string becomes available.
         If this method is called before the opening of websocket connection,
         `msg` is stored in `_cache0` and the message will be dispatched when
         a notebook with coresponding kernel id is connected.
@@ -48,7 +48,7 @@ class QueryStringSocketHandler(WebSocketHandler):
         Args:
             - msg (Dict): this dictionary contains the `kernel_id` to identify
             the waiting notebook and `payload` is the query string.
-        """        
+        """
         kernel_id = msg['kernel_id']
         payload = msg['payload']
         waiter = cls._waiters.get(kernel_id, None)

--- a/voila/utils.py
+++ b/voila/utils.py
@@ -7,10 +7,13 @@
 # The full license is in the file LICENSE, distributed with this software.  #
 #############################################################################
 
+import asyncio
 import os
-import websockets
-from typing import Awaitable
+import threading
 from enum import Enum
+from typing import Awaitable
+
+import websockets
 
 
 class ENV_VARIABLE(str, Enum):
@@ -20,6 +23,7 @@ class ENV_VARIABLE(str, Enum):
     VOILA_BASE_URL = 'VOILA_BASE_URL'
     VOILA_APP_IP = 'VOILA_APP_IP'
     VOILA_APP_PORT = 'VOILA_APP_PORT'
+    VOILA_APP_PROTOCOL = 'VOILA_APP_PROTOCOL'
     SERVER_NAME = 'SERVER_NAME'
     SERVER_PORT = 'SERVER_PORT'
     SCRIPT_NAME = 'SCRIPT_NAME'
@@ -45,7 +49,13 @@ def get_server_root_dir(settings):
     return root_dir
 
 
-async def get_user_query(url: str = None) -> Awaitable:
+async def _get_user_query(ws_url: str) -> Awaitable:
+    async with websockets.connect(ws_url) as websocket:
+        qs = await websocket.recv()
+    return qs
+
+
+def get_user_query(url: str = None) -> str:
     """Helper function to pause the execution of notebook and wait for
     the query string.
 
@@ -53,22 +63,34 @@ async def get_user_query(url: str = None) -> Awaitable:
         url (str, optional): Address to get user query string, if it is not
         provided, `voila` will figure out from the environment variables. Defaults to None.
 
-    Returns:
-        Awaitable: The query string provided by `QueryStringSocketHandler`.
+    Returns: The query string provided by `QueryStringSocketHandler`.
     """
-    if url is None:
-        base_url = os.getenv(ENV_VARIABLE.VOILA_BASE_URL, '/')
-        server_ip = os.getenv(ENV_VARIABLE.VOILA_APP_IP, '127.0.0.1')
-        server_port = os.getenv(ENV_VARIABLE.VOILA_APP_PORT, '8866')
-        url = f'ws://{server_ip}:{server_port}{base_url}voila/query'
 
     preheat_mode = os.getenv(ENV_VARIABLE.VOILA_PREHEAT, 'False')
+    if preheat_mode == 'False':
+        return os.getenv(ENV_VARIABLE.QUERY_STRING)
+
+    query_string = None
+    if url is None:
+        protocol = os.getenv(ENV_VARIABLE.VOILA_APP_PROTOCOL, 'ws')
+        server_ip = os.getenv(ENV_VARIABLE.VOILA_APP_IP, '127.0.0.1')
+        server_port = os.getenv(ENV_VARIABLE.VOILA_APP_PORT, '8866')
+        base_url = os.getenv(ENV_VARIABLE.VOILA_BASE_URL, '/')
+        url = f'{protocol}://{server_ip}:{server_port}{base_url}voila/query'
+
     kernel_id = os.getenv(ENV_VARIABLE.VOILA_KERNEL_ID)
     ws_url = f'{url}/{kernel_id}'
 
-    if preheat_mode == 'True':
-        async with websockets.connect(ws_url) as websocket:
-            qs = await websocket.recv()
-    else:
-        qs = os.getenv(ENV_VARIABLE.QUERY_STRING)
-    return qs
+    def inner():
+        nonlocal query_string
+        loop = asyncio.new_event_loop()
+        query_string = loop.run_until_complete(_get_user_query(ws_url))
+
+    thread = threading.Thread(target=inner)
+    try:
+        thread.start()
+        thread.join()
+    except (KeyboardInterrupt, SystemExit):
+        asyncio.get_event_loop().stop()
+
+    return query_string

--- a/voila/utils.py
+++ b/voila/utils.py
@@ -49,19 +49,20 @@ def get_server_root_dir(settings):
     return root_dir
 
 
-async def _get_user_query(ws_url: str) -> Awaitable:
+async def _get_query_string(ws_url: str) -> Awaitable:
     async with websockets.connect(ws_url) as websocket:
         qs = await websocket.recv()
     return qs
 
 
-def get_user_query(url: str = None) -> str:
+def get_query_string(url: str = None) -> str:
     """Helper function to pause the execution of notebook and wait for
     the query string.
 
     Args:
         url (str, optional): Address to get user query string, if it is not
-        provided, `voila` will figure out from the environment variables. Defaults to None.
+        provided, `voila` will figure out from the environment variables.
+        Defaults to None.
 
     Returns: The query string provided by `QueryStringSocketHandler`.
     """
@@ -84,7 +85,7 @@ def get_user_query(url: str = None) -> str:
     def inner():
         nonlocal query_string
         loop = asyncio.new_event_loop()
-        query_string = loop.run_until_complete(_get_user_query(ws_url))
+        query_string = loop.run_until_complete(_get_query_string(ws_url))
 
     thread = threading.Thread(target=inner)
     try:

--- a/voila/utils.py
+++ b/voila/utils.py
@@ -46,6 +46,16 @@ def get_server_root_dir(settings):
 
 
 async def get_user_query(url: str = None) -> Awaitable:
+    """Helper function to pause the execution of notebook and wait for
+    the query string.
+
+    Args:
+        url (str, optional): Address to get user query string, if it is not
+        provided, `voila` will figure out from the environment variables. Defaults to None.
+
+    Returns:
+        Awaitable: The query string provided by `QueryStringSocketHandler`.
+    """
     if url is None:
         base_url = os.getenv(ENV_VARIABLE.VOILA_BASE_URL, '/')
         server_ip = os.getenv(ENV_VARIABLE.VOILA_APP_IP, '127.0.0.1')

--- a/voila/voila_kernel_manager.py
+++ b/voila/voila_kernel_manager.py
@@ -287,6 +287,7 @@ def voila_kernel_manager_factory(base_class: Type[T], preheat_kernel: bool, defa
 
                 kernel_future = self.get_kernel(kernel_id)
                 task = asyncio.get_event_loop().create_task(renderer.generate_content_hybrid(kernel_id, kernel_future))
+                task.add_done_callback(lambda _: print('done', kernel_id))
                 return {'task': task, 'renderer': renderer, 'kernel_id': kernel_id}
 
             async def cull_kernel_if_idle(self, kernel_id: str):

--- a/voila/voila_kernel_manager.py
+++ b/voila/voila_kernel_manager.py
@@ -18,6 +18,7 @@ from traitlets.traitlets import Dict, Float, List, default
 from nbclient.util import ensure_async
 import re
 from .notebook_renderer import NotebookRenderer
+from .utils import ENV_VARIABLE
 
 T = TypeVar('T')
 
@@ -195,6 +196,8 @@ def voila_kernel_manager_factory(base_class: Type[T], preheat_kernel: bool, defa
                 for key in kernel_env_variables:
                     if key not in kernel_env:
                         kernel_env[key] = kernel_env_variables[key]
+                kernel_env[ENV_VARIABLE.VOILA_BASE_URL] = self.parent.base_url
+                kernel_env[ENV_VARIABLE.VOILA_PREHEAT] = 'True'
                 kwargs['env'] = kernel_env
 
                 heated = len(pool)
@@ -287,7 +290,6 @@ def voila_kernel_manager_factory(base_class: Type[T], preheat_kernel: bool, defa
 
                 kernel_future = self.get_kernel(kernel_id)
                 task = asyncio.get_event_loop().create_task(renderer.generate_content_hybrid(kernel_id, kernel_future))
-                task.add_done_callback(lambda _: print('done', kernel_id))
                 return {'task': task, 'renderer': renderer, 'kernel_id': kernel_id}
 
             async def cull_kernel_if_idle(self, kernel_id: str):

--- a/voila/voila_kernel_manager.py
+++ b/voila/voila_kernel_manager.py
@@ -94,7 +94,6 @@ def voila_kernel_manager_factory(base_class: Type[T], preheat_kernel: bool, defa
                 self.notebook_data: TypeDict = {}
                 self._pools: TypeDict[str, List[TypeDict]] = {}
                 self.root_dir = self.parent.root_dir
-                self._query_params = dict()
                 if self.parent.notebook_path is not None:
                     self.notebook_path = os.path.relpath(
                         self.parent.notebook_path, self.root_dir
@@ -359,17 +358,5 @@ def voila_kernel_manager_factory(base_class: Type[T], preheat_kernel: bool, defa
                     if kernel_id in data['kernel_ids']:
                         return nb_name
                 return None
-
-            def get_query_params(self, kernel_id: str, variable_name: str) -> str:
-                return self._query_params.get(kernel_id, {}).get(variable_name, [None])
-
-            def set_query_params(self, kernel_id: str, variable_name: str, value: str) -> None:
-                if kernel_id not in self._query_params:
-                    self._query_params[kernel_id] = {variable_name: value}
-                else:
-                    self._query_params[kernel_id][variable_name] = value
-
-            def remove_query_params(self, kernel_id: str) -> None:
-                self._query_params.pop(kernel_id, None)
 
     return VoilaKernelManager


### PR DESCRIPTION
## References

To benefit from the acceleration of preheating kernel mode, the notebooks need to be pre-rendered before users actually connect to Voilà. But in many real-world cases, the notebook requires some user-specific data to render correctly the widgets, which makes pre-rendering become impossible. To overcome this limit, Voilà offers a feature to treat the most used method for providing user data: the URL query string.

In normal mode, Voilà users can get the query string at run time through the ``QUERY_STRING`` environment variable:
```python
   import os
   query_string = os.getenv('QUERY_STRING') 
```
In preheating kernel mode, users can just replace the ``os.getenv`` call with the helper ``get_query_string`` from ``voila.utils``
```python
   from voila.utils import get_query_string
   query_string = get_query_string()
```
``get_query_string`` will pause the execution of notebook in the preheated kernel at its cell and wait for an actual user to connect to Voilà, then ``get_query_string`` will return the URL query string and continue the execution of remaining cells. 

If Voilà WebSocket handler is not started at the default protocol (`ws`), the default IP address (`127.0.0.1`) or the default port (`8866`), users need to provide these values through the environment variables ``VOILA_APP_PROTOCOL``, ``VOILA_APP_IP`` and ``VOILA_APP_PORT``. The easiest way is to set these variables in `voila.json` configuration file, for example:

```python
   # voila.json
   {
      ...
      "VoilaKernelManager": {
         "kernel_pools_config": { 
            "foo.ipynb": {
               "kernel_env_variables": { 
                  "VOILA_APP_IP": "192.168.1.1",
                  "VOILA_APP_PORT": "6789",
                  "VOILA_APP_PROTOCOL": "wss"
               }
            }
         },
      ...
      }
   } 
```

https://user-images.githubusercontent.com/4451292/136826458-9eb66cc6-8cfa-4f81-b6d8-0ff46de2522a.mp4

TODO
- [x] Create a handler to provide the query string associated with each kernel id.
- [x] Create a helper to pause the execution and wait for the query string in a notebook.
- [x] Add documentation 

## Code changes
- A new WebSocket handler `QueryStringSocketHandler` is added at endpoint `/voila/query/{kernel-id}`
- A new function`get_query_string` in `voila.utils`.
- New dependency `websockets`

## User-facing changes
- Users now can use query string with preheating kernel mode.

## Backwards-incompatible changes
N/A
