### PR TITLE
Add a separate line for `jupyter server extension enable` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Voilà can also be used as a Jupyter server extension, both with the
 To install the Jupyter server extension, run
 
 ```
-jupyter serverextension enable voila --sys-prefix
+jupyter serverextension enable voila
+jupyter server extension enable voila
 ```
 
 When running the Jupyter server, the Voilà app is accessible from the base url


### PR DESCRIPTION
This proposed change tries to clean up a bit of confusion about the server extension workflow.

I was running into an issue like https://github.com/voila-dashboards/voila/issues/561 . However, I wanted to keep my Jupyter install as a system package on Arch (obligatory "arch, btw!") rather than switching to conda. Thus, the addition of `--sys-prefix` to `jupyter serverextension enable` was not an option for me. I thus tried `jupyter serverextension enable voila`, but to no avail.

There's no Arch/AUR package for Voila just yet (I might make one later), so I'm using Voila via `pip install --user`.

However, I found out in https://github.com/voila-dashboards/voila/blob/88d55eaa418f497cc338a4a0602c961449b76de4/.binder/postBuild that `jupyter serverextension` and `jupyter server extension` are two different concepts (no idea why, honestly). I tried running `jupyter server extension enable --user voila`, and, well... voila! It works now.

So I'd like to propose this change as a "hey, this is confusing in the documentation; perhaps let's change it up in places!" idea.

## References

Addresses similar problems to #561 

## Code changes, User-facing changes, Backwards-incompatible changes

None whatsoever; just a README change. I'd be happy to also improve the docs once I get better understanding of why this is necessary.