### PR TITLE
Add token management

### DIFF
--- a/tests/app/token_test.py
+++ b/tests/app/token_test.py
@@ -1,0 +1,39 @@
+# test all objects that should be configurable
+import pytest
+import tornado
+
+import os
+
+from secrets import token_hex
+
+BASE_DIR = os.path.dirname(__file__)
+TOKEN = token_hex()
+
+
+@pytest.fixture
+def base_url():
+    return "/?token=%s" % TOKEN
+
+
+@pytest.fixture
+def voila_args_extra():
+    return ['--VoilaTest.token=%s' % TOKEN, '--VoilaExecutor.timeout=240']
+
+
+async def test_token(http_server_client, base_url):
+
+    response = await http_server_client.fetch(base_url)
+    assert response.code == 200
+    assert 'Hi Voilà' in response.body.decode('utf-8')
+
+
+async def test_missing_token(http_server_client):
+
+    with pytest.raises(tornado.httpclient.HTTPClientError, match='HTTP 404.*'):
+        await http_server_client.fetch('/')
+
+
+async def test_wrong_token(http_server_client):
+
+    with pytest.raises(tornado.httpclient.HTTPClientError, match='HTTP 404.*'):
+        await http_server_client.fetch("/?token=%s" % token_hex())

--- a/voila/app.py
+++ b/voila/app.py
@@ -33,6 +33,7 @@ import jinja2
 
 import tornado.ioloop
 import tornado.web
+from tornado.httputil import url_concat
 
 from traitlets.config.application import Application
 from traitlets.config.loader import Config
@@ -239,6 +240,10 @@ class Voila(Application):
                                  cannot be determined reliably by the Jupyter notebook server (proxified
                                  or containerized setups for example)."""))
 
+    token = Unicode(u'', config=True,
+                    help="""Specify a token for connexion, allowing only owners to access to the Notebook
+                         """)
+
     @property
     def display_url(self):
         if self.custom_display_url:
@@ -252,12 +257,12 @@ class Voila(Application):
                 ip = self.ip
             url = self._url(ip)
         # TODO: do we want to have the token?
-        # if self.token:
-        #     # Don't log full token if it came from config
-        #     token = self.token if self._token_generated else '...'
-        #     url = (url_concat(url, {'token': token})
-        #           + '\n or '
-        #           + url_concat(self._url('127.0.0.1'), {'token': token}))
+        if self.token:
+            # # Don't log full token if it came from config
+            # token = self.token if self._token_generated else '...'
+            url = (url_concat(url, {'token': self.token})
+                   + '\n or '
+                   + url_concat(self._url('127.0.0.1'), {'token': self.token}))
         return url
 
     @property
@@ -516,7 +521,8 @@ class Voila(Application):
         )
 
         tree_handler_conf = {
-            'voila_configuration': self.voila_configuration
+            'voila_configuration': self.voila_configuration,
+            'token': self.token
         }
         if self.notebook_path:
             handlers.append((
@@ -526,7 +532,8 @@ class Voila(Application):
                     'notebook_path': os.path.relpath(self.notebook_path, self.root_dir),
                     'template_paths': self.template_paths,
                     'config': self.config,
-                    'voila_configuration': self.voila_configuration
+                    'voila_configuration': self.voila_configuration,
+                    'token': self.token
                 }
             ))
         else:
@@ -540,8 +547,9 @@ class Voila(Application):
                  {
                      'template_paths': self.template_paths,
                      'config': self.config,
-                     'voila_configuration': self.voila_configuration
-                }),
+                     'voila_configuration': self.voila_configuration,
+                     'token': self.token
+                 }),
             ])
 
         self.app.add_handlers('.*$', handlers)
@@ -613,10 +621,9 @@ class Voila(Application):
         fd, open_file = tempfile.mkstemp(suffix='.html')
         # Write a temporary file to open in the browser
         with io.open(fd, 'w', encoding='utf-8') as fh:
-            # TODO: do we want to have the token?
-            # if self.token:
-            #     url = url_concat(url, {'token': self.token})
             url = url_path_join(self.connection_url, uri)
+            if self.token:
+                url = url_concat(url, {'token': self.token})
 
             jinja2_env = self.app.settings['jinja2_env']
             template = jinja2_env.get_template('browser-open.html')

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -30,11 +30,18 @@ class VoilaHandler(JupyterHandler):
         self.template_paths = kwargs.pop('template_paths', [])
         self.traitlet_config = kwargs.pop('config', None)
         self.voila_configuration = kwargs['voila_configuration']
+        self.voila_token = kwargs.pop('token', u'')
         # we want to avoid starting multiple kernels due to template mistakes
         self.kernel_started = False
 
     @tornado.web.authenticated
     async def get(self, path=None):
+        # Manage token
+        if self.voila_token:
+            token = self.get_argument("token", "")
+            if not token == self.voila_token:
+                raise tornado.web.HTTPError(404, 'you need a token to connect')
+
         # if the handler got a notebook_path argument, always serve that
         notebook_path = self.notebook_path or path
 

--- a/voila/treehandler.py
+++ b/voila/treehandler.py
@@ -20,6 +20,7 @@ class VoilaTreeHandler(JupyterHandler):
     def initialize(self, **kwargs):
         self.voila_configuration = kwargs['voila_configuration']
         self.allowed_extensions = list(self.voila_configuration.extension_language_mapping.keys()) + ['.ipynb']
+        self.voila_token = kwargs.pop('token', u'')
 
     def get_template(self, name):
         """Return the jinja template object for a given name"""
@@ -48,6 +49,13 @@ class VoilaTreeHandler(JupyterHandler):
 
     @web.authenticated
     def get(self, path=''):
+
+        # Manage token
+        if self.voila_token:
+            token = self.get_argument("token", "")
+            if not token == self.voila_token:
+                raise web.HTTPError(404, 'you need a token to connect')
+
         cm = self.contents_manager
 
         if cm.dir_exists(path=path):


### PR DESCRIPTION
Fix #825 by adding an optional token parameter when running Voila.
Token must be filled manually in command line, it is not automatically generated.
The token parameter must be provided in VoilaHandler and VoilaTreeHandler URL, otherwise a 404 error is thrown.