### PR TITLE
Updating Heroku deploy instructions

### DIFF
--- a/docs/source/deploy.rst
+++ b/docs/source/deploy.rst
@@ -120,13 +120,13 @@ High level instructions, specific to Voilà can be found below:
 
    .. code:: text
 
-       web: voila —-port=$PORT --no-browser
+       web: voila --port=$PORT --no-browser
 
    Or the following if you only want to show one notebook:
 
    .. code:: text
 
-       web: voila —-port=$PORT —-no-browser your_notebook.ipynb
+       web: voila --port=$PORT --no-browser your_notebook.ipynb
 
 4. Initialize your git repo and commit your code. At minimum you need to commit
    your notebooks, requirements.txt, runtime.txt, and the Procfile.

--- a/docs/source/deploy.rst
+++ b/docs/source/deploy.rst
@@ -108,12 +108,12 @@ High level instructions, specific to Voilà can be found below:
 
 1. Follow the steps of the official documentation to install the heroku
    cli and login on your machine.
-2. Add a file named runtime.txt to the project directory with the following
-   content:
+2. Add a file named runtime.txt to the project directory with a 
+   `valid Python runtime <https://github.com/heroku/heroku-buildpack-python#specify-a-python-runtime>`__:
 
    .. code:: text
 
-       python-3.7.3
+       python-3.9.9
 
 3. Add a file named Procfile to the project directory with the
    following content if you want to show all notebooks:

--- a/docs/source/deploy.rst
+++ b/docs/source/deploy.rst
@@ -109,7 +109,7 @@ High level instructions, specific to Voilà can be found below:
 1. Follow the steps of the official documentation to install the heroku
    cli and login on your machine.
 2. Add a file named runtime.txt to the project directory with a 
-   `valid Python runtime <https://github.com/heroku/heroku-buildpack-python#specify-a-python-runtime>`__:
+   `valid Python runtime <https://devcenter.heroku.com/articles/python-support#supported-runtimes>`__:
 
    .. code:: text
 


### PR DESCRIPTION
In addition to replacing a Unicode character with it's ascii replacement, I've also updated the Python runtime as the one listed is no longer valid. Specifically, I've:

- Updated the Python runtime
- Added a link to Heroku's docs on Python runtimes so if/when the new runtime becomes invalid, it is easy to find the updated one

I chose not to use the latest runtime (`3.10.0`) as I'm not sure that (based on #1027) that voila supports Python 3.10.x yet.