### PR TITLE
Update tests on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,6 +91,7 @@ jobs:
       
       - name: Install dependencies
         run: |
+          python -m pip install jupyterlab_pygments==0.1.0 pytest-cov flake8 ipywidgets matplotlib traitlets
           python -m pip install ".[test]"
           cd tests/test_template
           pip install .
@@ -100,5 +101,4 @@ jobs:
       - name: Run test
         run: |
           set VOILA_TEST_DEBUG=1
-          set VOILA_TEST_XEUS_CLING=1
           py.test tests/ --async-test-timeout=240

--- a/tests/app/preheat_activation_test.py
+++ b/tests/app/preheat_activation_test.py
@@ -15,7 +15,7 @@ def voila_notebook(notebook_directory):
 
 
 NOTEBOOK_EXECUTION_TIME = 2
-TIME_THRESHOLD = 1
+TIME_THRESHOLD = NOTEBOOK_EXECUTION_TIME
 
 
 async def send_request(sc, url, wait=0):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import os
 
 import pytest
 
+import time
 
 BASE_DIR = os.path.dirname(__file__)
 
@@ -30,3 +31,9 @@ def syntax_error_notebook_url(base_url):
 @pytest.fixture
 def voila_notebook(notebook_directory):
     return os.path.join(notebook_directory, 'print.ipynb')
+
+
+@pytest.fixture(autouse=True)
+def sleep_between_tests():
+    yield
+    time.sleep(1)


### PR DESCRIPTION
Replace `py.test` with `python -m pytest` to avoid some flaky tests like in https://github.com/voila-dashboards/voila/runs/4459572584?check_suite_focus=true