### PR TITLE
Turn off debug mode and remove warnings for `many_iopub_messages_test.py`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-10.15]
         python_version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,14 +31,14 @@ jobs:
 
     - name: Create the conda environment
       shell: bash -l {0}
-      run: mamba install -q python=${{ matrix.python_version }} pip jupyterlab_pygments==0.1.0 pytest-cov nodejs flake8 ipywidgets matplotlib xeus-cling openssl=1.1.1l
+      run: mamba install -q python=${{ matrix.python_version }} pip jupyterlab_pygments==0.1.0 pytest-cov nodejs yarn flake8 ipywidgets matplotlib xeus-cling openssl=1.1.1l
 
     - name: Install dependencies
       shell: bash -l {0}
       run: |
         whereis python
         python --version
-
+        yarn install --network-timeout 100000
         python -m pip install ".[test]"
         (cd tests/test_template; pip install .)
         (cd tests/skip_template; pip install .)
@@ -47,14 +47,14 @@ jobs:
       shell: bash -l {0}
       run: |
         pip install "traitlets>=5.0.3,<6"
-        VOILA_TEST_DEBUG=1 VOILA_TEST_XEUS_CLING=1 py.test tests/ --async-test-timeout=240
+        VOILA_TEST_XEUS_CLING=1 py.test tests/ --async-test-timeout=240
 
     - name: Run tests (with traitlets 4)
       shell: bash -l {0}
       run: |
         pip install "traitlets>=4,<5"
         pip install ipykernel==5.5.5
-        VOILA_TEST_DEBUG=1 VOILA_TEST_XEUS_CLING=1 py.test tests/ --async-test-timeout=240
+        VOILA_TEST_XEUS_CLING=1 py.test tests/ --async-test-timeout=240
         voila --help  # Making sure we can run `voila --help`
         # tests if voila sends a 'heartbeat' to avoid proxies from closing an apparently stale connection
         # Note that wget is the only easily available software that has a read-timeout
@@ -91,6 +91,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install jupyterlab_pygments==0.1.0 pytest-cov flake8 ipywidgets matplotlib traitlets
+          yarn install --network-timeout 100000
           python -m pip install ".[test]"
           cd tests/test_template
           pip install .

--- a/tests/app/cgi-test.py
+++ b/tests/app/cgi-test.py
@@ -11,8 +11,7 @@ def notebook_cgi_path(base_url):
 def voila_args(notebook_directory, voila_args_extra):
 
     return [
-        '--VoilaTest.root_dir=%r' % notebook_directory,
-        '--VoilaTest.log_level=DEBUG'
+        '--VoilaTest.root_dir=%r' % notebook_directory
     ] + voila_args_extra
 
 

--- a/tests/app/cwd_subdir_test.py
+++ b/tests/app/cwd_subdir_test.py
@@ -12,8 +12,7 @@ def cwd_subdir_notebook_url(base_url):
 @pytest.fixture
 def voila_args(notebook_directory, voila_args_extra):
     return [
-        '--VoilaTest.root_dir=%r' % notebook_directory,
-        '--VoilaTest.log_level=DEBUG',
+        '--VoilaTest.root_dir=%r' % notebook_directory
     ] + voila_args_extra
 
 

--- a/tests/app/many_iopub_messages_test.py
+++ b/tests/app/many_iopub_messages_test.py
@@ -19,6 +19,7 @@ def voila_notebook(notebook_directory):
     return os.path.join(notebook_directory, 'many_iopub_messages.ipynb')
 
 
+@pytest.mark.filterwarnings("ignore")
 async def test_template_cwd(http_server_client, base_url):
     response = await http_server_client.fetch(base_url, request_timeout=MAX_TIMEOUT_SECONDS+20)
     html_text = response.body.decode('utf-8')

--- a/tests/app/notebooks_test.py
+++ b/tests/app/notebooks_test.py
@@ -12,8 +12,7 @@ def notebook_other_comms_path(base_url):
 @pytest.fixture
 def voila_args(notebook_directory, voila_args_extra):
     return [
-        '--VoilaTest.root_dir=%r' % notebook_directory,
-        '--VoilaTest.log_level=DEBUG',
+        '--VoilaTest.root_dir=%r' % notebook_directory
     ] + voila_args_extra
 
 

--- a/tests/app/serve_directory_test.py
+++ b/tests/app/serve_directory_test.py
@@ -13,7 +13,7 @@ def preheat_mode():
 
 @pytest.fixture
 def voila_args(notebook_directory, voila_args_extra):
-    return ['--VoilaTest.root_dir=%r' % notebook_directory, '--VoilaTest.log_level=DEBUG'] + voila_args_extra
+    return ['--VoilaTest.root_dir=%r' % notebook_directory] + voila_args_extra
 
 
 async def test_print(http_server_client, print_notebook_url):

--- a/tests/app/tree_test.py
+++ b/tests/app/tree_test.py
@@ -9,7 +9,7 @@ def preheat_mode():
 
 @pytest.fixture
 def voila_args(notebook_directory, voila_args_extra):
-    return ['--VoilaTest.root_dir=%r' % notebook_directory, '--VoilaTest.log_level=DEBUG'] + voila_args_extra
+    return ['--VoilaTest.root_dir=%r' % notebook_directory] + voila_args_extra
 
 
 @pytest.fixture

--- a/tests/server/cwd_subdir_test.py
+++ b/tests/server/cwd_subdir_test.py
@@ -10,7 +10,7 @@ def cwd_subdir_notebook_url(base_url):
 
 @pytest.fixture
 def voila_args(notebook_directory, voila_args_extra):
-    return ['--VoilaTest.root_dir=%r' % notebook_directory, '--VoilaTest.log_level=DEBUG'] + voila_args_extra
+    return ['--VoilaTest.root_dir=%r' % notebook_directory] + voila_args_extra
 
 
 async def test_hello_world(http_server_client, cwd_subdir_notebook_url):

--- a/tests/server/tree_test.py
+++ b/tests/server/tree_test.py
@@ -4,7 +4,7 @@ import pytest
 
 @pytest.fixture
 def voila_args(notebook_directory, voila_args_extra):
-    return ['--VoilaTest.root_dir=%r' % notebook_directory, '--VoilaTest.log_level=DEBUG'] + voila_args_extra
+    return ['--VoilaTest.root_dir=%r' % notebook_directory] + voila_args_extra
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR aims to eliminate the flaky tests by 3 changes:

-  Turn off debug mode
-  Filter out the warnings of `many_iopub_messages_test` test
- Pin `macOS` version to 10.15 https://github.com/jupyter-xeus/xeus-cling/issues/426