### PR TITLE
Fix environment.yml file location in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To serve a directory of jupyter notebooks, run `voila` with no argument.
 For example, to render the example notebook `bqplot.ipynb` from this repository with Voilà, you can first update your current environment with the requirements of this notebook (in this case in a [conda environment](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) and render the notebook with
 
 ```
-mamba env update -f environment.yml
+mamba env update -f .binder/environment.yml
 cd notebooks/
 voila bqplot.ipynb
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -81,7 +81,7 @@ Commit the changes, create a new release tag, and update the `stable` branch (fo
 
 ```bash
 git checkout main
-git add voila/_version.py environment.yml
+git add voila/_version.py
 git commit -m "Release x.y.z"
 git tag x.y.z
 git checkout stable


### PR DESCRIPTION
## References

Fix #1051 

## Code changes

Fix README, also remove mention of `environment.yml` from the RELEASE docs

## User-facing changes

None

## Backwards-incompatible changes

None