### PR TITLE
Lab template: fix body tag

### DIFF
--- a/share/jupyter/voila/templates/lab/index.html.j2
+++ b/share/jupyter/voila/templates/lab/index.html.j2
@@ -35,9 +35,9 @@
 
 {%- block body_header -%}
 {% if resources.theme == 'dark' %}
-<body class="jp-Notebook theme-dark" data-base-url="{{resources.base_url}}voila/">
+<body class="jp-Notebook theme-dark" data-base-url="{{resources.base_url}}voila/" data-jp-theme-light="false" data-jp-theme-name="JupyterLab Dark">
 {% else %}
-<body class="jp-Notebook theme-light" data-base-url="{{resources.base_url}}voila/">
+<body class="jp-Notebook theme-light" data-base-url="{{resources.base_url}}voila/" data-jp-theme-light="true" data-jp-theme-name="JupyterLab Light">
 {% endif %}
 {{ spinner.html() }}
 <script>

--- a/share/jupyter/voila/templates/reveal/index.html.j2
+++ b/share/jupyter/voila/templates/reveal/index.html.j2
@@ -40,9 +40,13 @@
 {%- endblock html_head_css -%}
 
 {% block body_header %}
-  <body data-base-url="{{resources.base_url}}voila/">
-  <div class="reveal">
-  <div class="slides">
+{% if resources.theme == 'dark' %}
+<body class="jp-Notebook" data-base-url="{{resources.base_url}}voila/" data-jp-theme-light="false" data-jp-theme-name="JupyterLab Dark">
+{% else %}
+<body class="jp-Notebook" data-base-url="{{resources.base_url}}voila/" data-jp-theme-light="true" data-jp-theme-name="JupyterLab Light">
+{% endif %}
+<div class="reveal">
+<div class="slides">
 {% endblock body_header %}
 
 {% block footer_js %}


### PR DESCRIPTION
## References

In combination with https://github.com/jupyter/nbconvert/pull/1704, it fixes an issue where the background for Matplotlib figures is not correct.

## Code changes

Change the body tag to add the missing `data-jp-theme-light` and `data-jp-theme-name` properties.

## User-facing changes

### Before

![before](https://user-images.githubusercontent.com/21197331/149129343-da0d7e31-9809-4a80-8e1d-0d27871768b7.png)


### After

![after](https://user-images.githubusercontent.com/21197331/149129357-822c6c0b-6f07-4495-be21-c7064011940d.png)


## Backwards-incompatible changes

None
