### PR TITLE
Allow all lab templates to use the lab theme

### DIFF
--- a/share/jupyter/voila/templates/lab/browser-open.html
+++ b/share/jupyter/voila/templates/lab/browser-open.html
@@ -1,0 +1,29 @@
+{% extends "page.html" %}
+
+{% block title %} Opening Voilà {% endblock %}
+
+{% block stylesheets %}
+  {{ super() }}
+
+  <style>
+    body {
+      background-color: var(--jp-layout-color0);
+      color: var(--jp-ui-font-color0);
+    }
+
+    .voila-link {
+      color: var(--jp-content-link-color);
+    }
+  </style>
+{% endblock %}
+
+{% block meta %}
+  <meta http-equiv="refresh" content="1;url={{ open_url }}" />
+{% endblock %}
+
+{% block body %}
+  <p>
+    This page should redirect you to Voilà. If it doesn't,
+    <a class="voila-link" href="{{ open_url }}">click here to go to Voilà</a>.
+  </p>
+{% endblock %}

--- a/share/jupyter/voila/templates/lab/page.html
+++ b/share/jupyter/voila/templates/lab/page.html
@@ -1,0 +1,13 @@
+{%- extends 'voila/templates/base/page.html' -%}
+
+{% block stylesheets %}
+{% if theme == 'dark' %}
+    {{ include_css("static/index.css") }}
+    {{ include_css("static/theme-dark.css") }}
+{% elif theme == 'light'  %}
+    {{ include_css("static/index.css") }}
+    {{ include_css("static/theme-light.css") }}
+{% else %}
+<!-- TODO: Use custom css from theme labextension -->
+{% endif %}
+{% endblock %}

--- a/share/jupyter/voila/templates/lab/tree.html
+++ b/share/jupyter/voila/templates/lab/tree.html
@@ -1,0 +1,93 @@
+{% extends "page.html" %}
+
+{% block title %}{{ page_title }}{% endblock %}
+
+{% block stylesheets %}
+  {{ super() }}
+
+  <style>
+    body {
+      background-color: var(--jp-layout-color0);
+    }
+
+    .list-header {
+      width: 80%;
+      margin-top: 50px;
+      margin-left: auto;
+      margin-right: auto;
+      padding: 0px;
+      border-style: solid;
+      border-width: var(--jp-border-width);
+      border-color: var(--jp-border-color2);
+      border-bottom: none;
+      background-color: var(--jp-layout-color2)
+    }
+
+    .list-header-text {
+      color: var(--jp-ui-font-color0);
+      font-size: var(--jp-ui-font-size1);
+      padding: 10px
+    }
+
+    .voila-notebooks {
+      background-color: var(--jp-layout-color1);
+      width: 80%;
+      margin: auto;
+      padding: 0px;
+      border-style: solid;
+      border-width: var(--jp-border-width);
+      border-color: var(--jp-border-color0);
+      border-radius: var(--jp-border-radius);
+    }
+
+    .voila-notebooks > li {
+      color: var(--jp-ui-font-color1);
+      list-style: none;
+      border-bottom-style: solid;
+      border-bottom-width: var(--jp-border-width);
+      border-bottom-color: var(--jp-border-color0);
+    }
+
+    .voila-notebooks > li:hover {
+      background-color: var(--jp-layout-color2);
+    }
+
+    .voila-notebooks > li:last-child {
+      border: none
+    }
+
+    .voila-notebooks > li > a {
+      display: block;
+      width: 100%;
+      height: 100%;
+      padding: 10px;
+    }
+
+    .voila-notebooks > li > a > i {
+      padding: 0 10px
+    }
+  </style>
+{% endblock %}
+
+{% block body %}
+  <div class="list-header">
+      <div class="list-header-text">
+          Select items to open with Voilà.
+      </div>
+  </div>
+
+  <ul class="voila-notebooks">
+    {% if breadcrumbs|length > 1: %}
+      <li><a href="{{ breadcrumbs[-2][0] }}"><i class="fa fa-folder"></i>..</a></li>
+    {% endif %}
+
+    {% for content in contents.content %}
+      {% if content.type in ['notebook', 'file'] %}
+        <li><a href="{{ base_url }}voila/render/{{ content.path }}"><i class="fa fa-book"></i>{{content.name}}</a></li>
+      {% endif %}
+      {% if content.type == 'directory' %}
+        <li><a href="{{ base_url }}voila/tree/{{ content.path }}"><i class="fa fa-folder"></i>{{content.name}}</a></li>
+      {% endif %}
+    {% endfor %}
+  </ul>
+{% endblock %}

--- a/voila/app.py
+++ b/voila/app.py
@@ -6,7 +6,6 @@
 #                                                                           #
 # The full license is in the file LICENSE, distributed with this software.  #
 #############################################################################
-
 import gettext
 import io
 import sys
@@ -62,6 +61,7 @@ from .exporter import VoilaExporter
 from .shutdown_kernel_handler import VoilaShutdownKernelHandler
 from .voila_kernel_manager import voila_kernel_manager_factory
 from .query_parameters_handler import QueryStringSocketHandler
+from .utils import create_include_assets_functions
 
 _kernel_id_regex = r"(?P<kernel_id>\w+-\w+-\w+-\w+-\w+)"
 
@@ -618,9 +618,15 @@ class Voila(Application):
             #     url = url_concat(url, {'token': self.token})
             url = url_path_join(self.connection_url, uri)
 
+            include_assets_functions = create_include_assets_functions(self.voila_configuration.template, url)
+
             jinja2_env = self.app.settings['jinja2_env']
             template = jinja2_env.get_template('browser-open.html')
-            fh.write(template.render(open_url=url, base_url=url))
+            fh.write(template.render(
+                open_url=url, base_url=url,
+                theme=self.voila_configuration.theme,
+                **include_assets_functions
+            ))
 
         def target():
             return browser.open(urljoin('file:', pathname2url(open_file)), new=self.webbrowser_open_new)

--- a/voila/exporter.py
+++ b/voila/exporter.py
@@ -13,7 +13,6 @@ import traitlets
 from traitlets.config import Config
 
 from jinja2 import contextfilter
-import jinja2
 
 from nbconvert.filters.markdown_mistune import IPythonRenderer, MarkdownWithMath
 from nbconvert.exporters.html import HTMLExporter
@@ -21,6 +20,7 @@ from nbconvert.exporters.templateexporter import TemplateExporter
 from nbconvert.filters.highlight import Highlight2HTML
 
 from .static_file_handler import TemplateStaticFileHandler
+from .utils import create_include_assets_functions
 
 
 class VoilaMarkdownRenderer(IPythonRenderer):
@@ -120,26 +120,10 @@ class VoilaExporter(HTMLExporter):
         return TemplateStaticFileHandler.make_static_url(settings, f'{self.template_name}/static/{path}')
 
     def _init_resources(self, resources):
-        def make_url(path):
-            # similar to static_url, but does not assume the static prefix
-            settings = {
-                'static_url_prefix': f'{self.base_url}voila/templates/',
-                'static_path': None  # not used in TemplateStaticFileHandler.get_absolute_path
-            }
-            return TemplateStaticFileHandler.make_static_url(settings, f'{self.template_name}/{path}')
-
-        def include_css(name):
-            code = f'<link rel="stylesheet" type="text/css" href="{make_url(name)}">'
-            return jinja2.Markup(code)
-
-        def include_js(name):
-            code = f'<script src="{make_url(name)}"></script>'
-            return jinja2.Markup(code)
-
-        def include_url(name):
-            return jinja2.Markup(make_url(name))
         resources = super(VoilaExporter, self)._init_resources(resources)
-        resources['include_css'] = include_css
-        resources['include_js'] = include_js
-        resources['include_url'] = include_url
+
+        include_assets_functions = create_include_assets_functions(self.template_name, self.base_url)
+
+        resources.update(include_assets_functions)
+
         return resources

--- a/voila/treehandler.py
+++ b/voila/treehandler.py
@@ -13,7 +13,7 @@ from tornado import web
 from jupyter_server.base.handlers import JupyterHandler
 from jupyter_server.utils import url_path_join, url_escape
 
-from .utils import get_server_root_dir
+from .utils import get_server_root_dir, create_include_assets_functions
 
 
 class VoilaTreeHandler(JupyterHandler):
@@ -66,13 +66,18 @@ class VoilaTreeHandler(JupyterHandler):
 
             contents['content'] = sorted(contents['content'], key=lambda i: i['name'])
             contents['content'] = filter(allowed_content, contents['content'])
+
+            include_assets_functions = create_include_assets_functions(self.voila_configuration.template, self.base_url)
+
             self.write(self.render_template('tree.html',
                        page_title=page_title,
                        notebook_path=path,
                        breadcrumbs=breadcrumbs,
                        contents=contents,
                        terminals_available=False,
-                       server_root=get_server_root_dir(self.settings)))
+                       server_root=get_server_root_dir(self.settings),
+                       theme=self.voila_configuration.theme,
+                       **include_assets_functions))
         elif cm.file_exists(path):
             # it's not a directory, we have redirecting to do
             model = cm.get(path, content=False)


### PR DESCRIPTION
## Code changes

Lab template: reuse lab CSS variables for the "tree" and "browser-open" pages

## User-facing changes

### Using the light theme:

https://user-images.githubusercontent.com/21197331/150176598-1718abcc-f998-410d-bf40-f5ca1b4c7500.mp4

### Using the dark theme:

https://user-images.githubusercontent.com/21197331/150176619-e26bc081-3f58-42f6-9939-ca703831175e.mp4

## Backwards-incompatible changes

None