### PR TITLE
Update JupyterLab extension logo

### DIFF
--- a/packages/jupyterlab-preview/style/voila.svg
+++ b/packages/jupyterlab-preview/style/voila.svg
@@ -1,10 +1,15 @@
-<svg width="330" height="330" data-name="Calque 1" version="1.1" viewBox="0 0 330 330" xmlns="http://www.w3.org/2000/svg">
+<svg width="308.95" height="308.95" data-name="Calque 1" version="1.1" viewBox="0 0 308.95 308.95" xmlns="http://www.w3.org/2000/svg">
  <defs>
-  <style>.cls-1{fill:#5dbcaf;}.cls-2{fill:#268380;}.cls-3{fill:#f8e14b;}</style>
+  <style>
+    [data-jp-theme-light='true'] .jp-VoilaColor1 {fill:#268380;}
+    [data-jp-theme-light='true'] .jp-VoilaColor2 {fill:#f8e14b;}
+    [data-jp-theme-light='false'] .jp-VoilaColor1 {fill:#555454;}
+    [data-jp-theme-light='false'] .jp-VoilaColor2 {fill:#f38c02;}
+  </style>
  </defs>
  <title>Voila</title>
- <g class="jp-icon3">
-  <path class="cls-2" d="m165 320c-85.47 0-155-69.53-155-155s69.53-155 155-155 155 69.53 155 155-69.53 155-155 155zm0-275.49a120.49 120.49 0 1 0 120.49 120.49 120.62 120.62 0 0 0-120.49-120.49z" fill="#616161"/>
-  <path class="cls-3" d="m165 320c-85.47 0-155-69.53-155-155a17.26 17.26 0 1 1 34.51 0 120.62 120.62 0 0 0 120.49 120.49 17.26 17.26 0 1 1 0 34.51z" fill="#f8e14b"/>
-</g>
+ <g class="jp-icon3" transform="translate(-95.032 -95.527)">
+  <path class="jp-VoilaColor1" d="m391.05 343h-282.05a14 14 0 0 1 0-27.91h282.1a14 14 0 0 1 0 27.91z"/>
+  <path class="jp-VoilaColor2" d="m108.94 276.18a14 14 0 0 1-12.41-20.3l35.81-70.07c12.77-25.09 29.66-28.81 38.53-28.81s25.75 3.75 38.53 28.86l24.25 47.64c5.11 10.06 10.56 13.62 13.67 13.62s8.55-3.56 13.66-13.62l24.25-47.64c12.77-25.14 29.63-28.86 38.53-28.86 8.91 0 25.76 3.76 38.54 28.87a14 14 0 0 1-24.87 12.66c-5.11-10.06-10.56-13.62-13.67-13.62s-8.55 3.56-13.66 13.62l-24.25 47.64c-12.78 25.08-29.63 28.83-38.53 28.83s-25.76-3.75-38.54-28.87l-24.24-47.64c-5.12-10.06-10.56-13.62-13.67-13.62s-8.55 3.56-13.67 13.62l-35.82 70.09a14 14 0 0 1-12.44 7.6z"/>
+ </g>
 </svg>


### PR DESCRIPTION
## References

Fix https://github.com/voila-dashboards/voila/issues/461

## Code changes

Changes the labextension logo, from the spinner to:

![68325021-ebef2900-00c8-11ea-9e22-ce66ac54a2a2](https://user-images.githubusercontent.com/21197331/153611145-f4150b86-a4ff-4f05-8c74-a74c659745e4.png)

## Backwards-incompatible changes

None