### PR TITLE
fix: ignore updates that happen before the full state is send

### DIFF
--- a/packages/voila/src/manager.ts
+++ b/packages/voila/src/manager.ts
@@ -368,7 +368,8 @@ export class WidgetManager extends JupyterLabManager {
             msg.buffers
           );
         }
-        if (msg.content.data.method === 'update') {
+        // filter out update messages that don't include the full widget state
+        if (msg.content.data.method === 'update' && msg.content.data.state._model_name) {
           resolve({ comm: comm, msg: msg });
         }
       });


### PR DESCRIPTION
This can happen when the kernel is updating a widget from a thread
at the same time as when we are requesting the states.

When this happens, we get an update without the full widget state, which
causes the widget creation fo fail (since model and module are all undefined)

Note that this does not affect the new faster way, so ipywidgets 8 should
not be affected by this bug.

