### PR TITLE
Fix wait_for_request

### DIFF
--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -410,7 +410,7 @@ In preheating kernel mode, users can prepend with ``wait_for_request`` from ``vo
 
 ``wait_for_request`` will pause the execution of the notebook in the preheated kernel at this cell and wait for an actual user to connect to Voilà, set the request info environment variables and then continue the execution of the remaining cells.
 
-If the Voilà websocket handler is not started with the default protocol (`ws`), the default IP address (`127.0.0.1`) or the default port (`8866`), users need to provide these values through the environment variables ``VOILA_APP_PROTOCOL``, ``VOILA_APP_IP`` and ``VOILA_APP_PORT``. The easiest way is to set these variables in the `voila.json` configuration file, for example:
+If the Voilà websocket handler is not started with the default protocol (`ws`), the default IP address (`127.0.0.1`) the default port (`8866`) or with url suffix, users need to provide these values through the environment variables ``VOILA_WS_PROTOCOL``, ``VOILA_APP_IP``, ``VOILA_APP_PORT`` and ``VOILA_WS_BASE_URL``. The easiest way is to set these variables in the `voila.json` configuration file, for example:
 
 .. code-block:: python
 
@@ -423,7 +423,7 @@ If the Voilà websocket handler is not started with the default protocol (`ws`),
                "kernel_env_variables": { 
                   "VOILA_APP_IP": "192.168.1.1",
                   "VOILA_APP_PORT": "6789",
-                  "VOILA_APP_PROTOCOL": "wss"
+                  "VOILA_WS_PROTOCOL": "wss"
                }
             }
          },

--- a/voila/voila_kernel_manager.py
+++ b/voila/voila_kernel_manager.py
@@ -175,13 +175,16 @@ def voila_kernel_manager_factory(base_class: Type[T], preheat_kernel: bool, defa
                 except RuntimeError:
                     loop = asyncio.new_event_loop()
                     asyncio.set_event_loop(loop)
-                if notebook_name in self.kernel_pools_config:
-                    kernel_size = self.kernel_pools_config[notebook_name].get(
-                        'pool_size', 1
-                    )
-                else:
-                    default_config = self.kernel_pools_config.get('default', {})
-                    kernel_size = default_config.get('pool_size', 1)
+                default_config: dict = self.kernel_pools_config.get('default', {})
+                notebook_config: dict = self.kernel_pools_config.get(
+                    notebook_name, default_config
+                )
+                kernel_env_variables: dict = notebook_config.get(
+                    'kernel_env_variables', default_config.get('kernel_env_variables', {})
+                )
+                kernel_size: int = notebook_config.get(
+                    'pool_size', default_config.get('pool_size', 1)
+                )
                 pool = self._pools.get(notebook_name, [])
                 self._pools[notebook_name] = pool
                 if 'path' not in kwargs:
@@ -193,7 +196,7 @@ def voila_kernel_manager_factory(base_class: Type[T], preheat_kernel: bool, defa
                 kernel_env = os.environ.copy()
                 kernel_env_arg = kwargs.get('env', {})
                 kernel_env.update(kernel_env_arg)
-                kernel_env_variables = self.kernel_pools_config.get(notebook_name, {}).get('kernel_env_variables', {})
+
                 for key in kernel_env_variables:
                     if key not in kernel_env:
                         kernel_env[key] = kernel_env_variables[key]


### PR DESCRIPTION
<!--
Thanks for contributing to Voilà!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/voila-dashboards/voila/blob/main/CONTRIBUTING.md
-->

## References
#1123 
- Add `VOILA_WS_BASE_URL` variable to define the URL suffix for the `wait_for_request` websocket handle.
- Add connection timeout (10s) for the above connection.
<!-- Note issue numbers this pull request addresses. -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Check `request_info` variable before calling `json.loads`

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!--
For visual changes, include before and after screenshots here.

You will also need to update the reference screenshots for the Galata visual regression tests,
you can do this automatically by commenting "Please update galata references" in the PR.
-->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to Voilà public APIs. -->
