### PR TITLE
feat: support all kernel ServerConnection options

### DIFF
--- a/packages/voila/src/kernel.ts
+++ b/packages/voila/src/kernel.ts
@@ -15,11 +15,12 @@ import { KernelConnection } from '@jupyterlab/services/lib/kernel/default';
 
 export async function connectKernel(
   baseUrl?: string,
-  kernelId?: string
+  kernelId?: string,
+  options?: Partial<ServerConnection.ISettings>
 ): Promise<Kernel.IKernelConnection | undefined> {
   baseUrl = baseUrl ?? PageConfig.getBaseUrl();
   kernelId = kernelId ?? PageConfig.getOption('kernelId');
-  const serverSettings = ServerConnection.makeSettings({ baseUrl });
+  const serverSettings = ServerConnection.makeSettings({ baseUrl, ...options });
 
   const model = await KernelAPI.getKernelModel(kernelId, serverSettings);
   if (!model) {


### PR DESCRIPTION
We only exposed baseUrl and kernelId in connectKernel, with this we expose all ServerConnection options.