### PR TITLE
Fix default VOILA_WS_BASE_URL value in preheating mode

### DIFF
--- a/tests/app/preheat_with_query_string_test.py
+++ b/tests/app/preheat_with_query_string_test.py
@@ -1,0 +1,65 @@
+import pytest
+import time
+import asyncio
+import os
+
+
+@pytest.fixture(params=[['--Voila.base_url="/base/"'], []])
+def using_base_url(request):
+    return request.param
+
+
+@pytest.fixture(params=[['--Voila.server_url="/server/"'], []])
+def using_server_url(request):
+    return request.param
+
+
+@pytest.fixture()
+def voila_args_extra(using_server_url, using_base_url):
+    return using_server_url + using_base_url
+
+
+@pytest.fixture
+def preheat_mode(http_server_port):
+    os.environ['VOILA_APP_PORT'] = str(http_server_port[-1])
+    return True
+
+
+@pytest.fixture
+def voila_notebook(notebook_directory):
+    return os.path.join(
+        notebook_directory, 'preheat', 'get_query_string.ipynb'
+    )
+
+
+NOTEBOOK_EXECUTION_TIME = 2
+TIME_THRESHOLD = NOTEBOOK_EXECUTION_TIME
+
+
+async def send_request(sc, url, wait=0):
+    await asyncio.sleep(wait)
+    real_time = time.time()
+    response = await sc.fetch(url)
+    real_time = time.time() - real_time
+    html_text = response.body.decode('utf-8')
+    return real_time, html_text
+
+
+async def test_request_with_query(
+    http_server_client, base_url, using_base_url, using_server_url
+):
+    """
+    We sent request with query parameter, `get_query_string` should
+    return value.
+    """
+    if len(using_server_url) > 0:
+        url = '/server/?foo=bar'
+    else:
+        if len(using_base_url) > 0:
+            url = '/base/?foo=bar'
+        else:
+            url = f'{base_url}?foo=bar'
+    _, html_text = await send_request(
+        sc=http_server_client, url=url, wait=NOTEBOOK_EXECUTION_TIME + 1
+    )
+    assert 'foo=bar' in html_text

--- a/tests/notebooks/preheat/get_query_string.ipynb
+++ b/tests/notebooks/preheat/get_query_string.ipynb
@@ -1,0 +1,36 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7efe3e8f-4b8d-4fd3-99d1-b06d79b88ae2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from voila.utils import get_query_string\n",
+    "print(get_query_string())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/voila/app.py
+++ b/voila/app.py
@@ -409,6 +409,9 @@ class Voila(Application):
         self.log.info('Storing connection files in %s.' % self.connection_dir)
         self.log.info('Serving static files from %s.' % self.static_root)
 
+        # default server_url to base_url
+        self.server_url = self.server_url or self.base_url
+
         self.kernel_spec_manager = KernelSpecManager(
             parent=self
         )
@@ -443,9 +446,6 @@ class Voila(Application):
         env = jinja2.Environment(loader=jinja2.FileSystemLoader(self.template_paths), extensions=['jinja2.ext.i18n'], **jenv_opt)
         nbui = gettext.translation('nbui', localedir=os.path.join(ROOT, 'i18n'), fallback=True)
         env.install_gettext_translations(nbui, newstyle=False)
-
-        # default server_url to base_url
-        self.server_url = self.server_url or self.base_url
 
         self.app = tornado.web.Application(
             base_url=self.base_url,

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -186,6 +186,7 @@ class VoilaHandler(BaseVoilaHandler):
             kernel_env = {**os.environ, **request_info}
             kernel_env[ENV_VARIABLE.VOILA_PREHEAT] = 'False'
             kernel_env[ENV_VARIABLE.VOILA_BASE_URL] = self.base_url
+            kernel_env[ENV_VARIABLE.VOILA_SERVER_URL] = self.settings.get('server_url', '/')
             kernel_id = await ensure_async(
                 (
                     self.kernel_manager.start_kernel(

--- a/voila/utils.py
+++ b/voila/utils.py
@@ -29,6 +29,7 @@ class ENV_VARIABLE(str, Enum):
     VOILA_PREHEAT = 'VOILA_PREHEAT'
     VOILA_KERNEL_ID = 'VOILA_KERNEL_ID'
     VOILA_BASE_URL = 'VOILA_BASE_URL'
+    VOILA_SERVER_URL = 'VOILA_SERVER_URL'
     VOILA_APP_IP = 'VOILA_APP_IP'
     VOILA_APP_PORT = 'VOILA_APP_PORT'
     VOILA_WS_PROTOCOL = 'VOILA_WS_PROTOCOL'
@@ -89,9 +90,9 @@ def wait_for_request(url: str = None) -> str:
         protocol = os.getenv(ENV_VARIABLE.VOILA_WS_PROTOCOL, 'ws')
         server_ip = os.getenv(ENV_VARIABLE.VOILA_APP_IP, '127.0.0.1')
         server_port = os.getenv(ENV_VARIABLE.VOILA_APP_PORT, '8866')
-        # Use `VOILA_BASE_URL` if `VOILA_WS_BASE_URL` not specified.
-        base_url = os.getenv(ENV_VARIABLE.VOILA_BASE_URL, '/')
-        ws_base_url = os.getenv(ENV_VARIABLE.VOILA_WS_BASE_URL, base_url)
+        server_url = os.getenv(ENV_VARIABLE.VOILA_SERVER_URL, '/')
+        # Use `VOILA_SERVER_URL` if `VOILA_WS_BASE_URL` not specified.
+        ws_base_url = os.getenv(ENV_VARIABLE.VOILA_WS_BASE_URL, server_url)
         url = f'{protocol}://{server_ip}:{server_port}{ws_base_url}voila/query'
 
     kernel_id = os.getenv(ENV_VARIABLE.VOILA_KERNEL_ID)

--- a/voila/utils.py
+++ b/voila/utils.py
@@ -89,8 +89,10 @@ def wait_for_request(url: str = None) -> str:
         protocol = os.getenv(ENV_VARIABLE.VOILA_WS_PROTOCOL, 'ws')
         server_ip = os.getenv(ENV_VARIABLE.VOILA_APP_IP, '127.0.0.1')
         server_port = os.getenv(ENV_VARIABLE.VOILA_APP_PORT, '8866')
-        base_url = os.getenv(ENV_VARIABLE.VOILA_WS_BASE_URL, '/')
-        url = f'{protocol}://{server_ip}:{server_port}{base_url}voila/query'
+        # Use `VOILA_BASE_URL` if `VOILA_WS_BASE_URL` not specified.
+        base_url = os.getenv(ENV_VARIABLE.VOILA_BASE_URL, '/')
+        ws_base_url = os.getenv(ENV_VARIABLE.VOILA_WS_BASE_URL, base_url)
+        url = f'{protocol}://{server_ip}:{server_port}{ws_base_url}voila/query'
 
     kernel_id = os.getenv(ENV_VARIABLE.VOILA_KERNEL_ID)
     ws_url = f'{url}/{kernel_id}'

--- a/voila/voila_kernel_manager.py
+++ b/voila/voila_kernel_manager.py
@@ -201,6 +201,7 @@ def voila_kernel_manager_factory(base_class: Type[T], preheat_kernel: bool, defa
                     if key not in kernel_env:
                         kernel_env[key] = kernel_env_variables[key]
                 kernel_env[ENV_VARIABLE.VOILA_BASE_URL] = self.parent.base_url
+                kernel_env[ENV_VARIABLE.VOILA_SERVER_URL] = self.parent.server_url
                 kernel_env[ENV_VARIABLE.VOILA_PREHEAT] = 'True'
                 kwargs['env'] = kernel_env
 


### PR DESCRIPTION
<!--
Thanks for contributing to Voilà!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/voila-dashboards/voila/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses. -->
Resolves #1140.
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Use `VOILA_BASE_URL` as the default value if `VOILA_WS_BASE_URL` has not been specified to make the `wait_for_request` and `get_query_string` functions backwards-compatible in the preheating mode.

