### PR TITLE
[tests] rerun failed tests 2 times in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Run tests
       shell: bash -l {0}
       run: |
-        VOILA_TEST_XEUS_CLING=1 py.test tests/ --async-test-timeout=240 --reruns 1 --reruns-delay 1
+        VOILA_TEST_XEUS_CLING=1 py.test tests/ --async-test-timeout=240 --reruns 2 --reruns-delay 1
         voila --help  # Making sure we can run `voila --help`
         # tests if voila sends a 'heartbeat' to avoid proxies from closing an apparently stale connection
         # Note that wget is the only easily available software that has a read-timeout
@@ -93,4 +93,4 @@ jobs:
       - name: Run test
         run: |
           set VOILA_TEST_DEBUG=1
-          py.test tests/ --async-test-timeout=240 --reruns 1 --reruns-delay 1
+          py.test tests/ --async-test-timeout=240 --reruns 2 --reruns-delay 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Create the conda environment
       shell: bash -l {0}
-      run: mamba install -q python=${{ matrix.python_version }} pip jupyterlab_pygments==0.1.0 pytest-cov nodejs yarn flake8 ipywidgets matplotlib xeus-cling openssl=1.1.1l "traitlets>=5.0.3,<6"
+      run: mamba install -q python=${{ matrix.python_version }} pip jupyterlab_pygments==0.1.0 pytest-cov pytest-rerunfailures nodejs yarn flake8 ipywidgets matplotlib xeus-cling openssl=1.1.1l "traitlets>=5.0.3,<6"
 
     - name: Install dependencies
       shell: bash -l {0}
@@ -46,7 +46,7 @@ jobs:
     - name: Run tests
       shell: bash -l {0}
       run: |
-        VOILA_TEST_XEUS_CLING=1 py.test tests/ --async-test-timeout=240
+        VOILA_TEST_XEUS_CLING=1 py.test tests/ --async-test-timeout=240 --reruns 1 --reruns-delay 1
         voila --help  # Making sure we can run `voila --help`
         # tests if voila sends a 'heartbeat' to avoid proxies from closing an apparently stale connection
         # Note that wget is the only easily available software that has a read-timeout
@@ -82,7 +82,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install jupyterlab_pygments==0.1.0 pytest-cov flake8 ipywidgets matplotlib traitlets
+          python -m pip install jupyterlab_pygments==0.1.0 pytest-cov pytest-rereunfailures flake8 ipywidgets matplotlib traitlets
           yarn install --network-timeout 100000
           python -m pip install ".[test]"
           cd tests/test_template
@@ -93,4 +93,4 @@ jobs:
       - name: Run test
         run: |
           set VOILA_TEST_DEBUG=1
-          py.test tests/ --async-test-timeout=240
+          py.test tests/ --async-test-timeout=240 --reruns 1 --reruns-delay 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ test =
     matplotlib
     mock
     pytest
+    pytest-rerunfailures
     pytest-tornasync
 
 visual_test =


### PR DESCRIPTION
<!--
Thanks for contributing to Voilà!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/voila-dashboards/voila/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses. -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Adds a new test dependency and updates CI tests to rerun failures 2 times to minimize the chance of flaky tests failing.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!--
For visual changes, include before and after screenshots here.

You will also need to update the reference screenshots for the Galata visual regression tests,
you can do this automatically by commenting "Please update galata references" in the PR.
-->

## Backwards-incompatible changes

N/A
<!-- Describe any backwards-incompatible changes to Voilà public APIs. -->
