### PR TITLE
default to the base package to let the CDN handle browser/main resolution

### DIFF
--- a/packages/voila/src/loader.ts
+++ b/packages/voila/src/loader.ts
@@ -41,6 +41,11 @@ function moduleNameToCDNUrl(moduleName: string, moduleVersion: string) {
     fileName = moduleName.substr(index + 1);
     packageName = moduleName.substr(0, index);
   }
+
+  if (moduleVersion.startsWith('~')) {
+    moduleVersion = moduleVersion.slice(1);
+  }
+
   return {
     packageRoot: `${cdn}${packageName}@${moduleVersion}`,
     pathGuess: `/dist/${fileName}`

--- a/packages/voila/src/loader.ts
+++ b/packages/voila/src/loader.ts
@@ -81,22 +81,23 @@ export function requireLoader(
       const conf: { paths: { [key: string]: string } } = { paths: {} };
 
       // First, try to resolve with the CDN.
-      // For unpkg (the default), we just use the base
-      // package since unpkg will try to leverage
-      // the `main` or `browser` bundle in the
-      // extension's package.json
-
+      // We default to the previous behavior
+      // of trying for a full path. NOTE: in the
+      // future, we should let the CDN resolve itself
+      // based on the package.json contents (the next
+      // case below)
       const { packageRoot, pathGuess } = moduleNameToCDNUrl(
         moduleName,
         moduleVersion
       );
-      conf.paths[moduleName] = `${packageRoot}?`; // NOTE: the `?` is added to avoid require appending a .js
+      conf.paths[moduleName] = `${packageRoot}${pathGuess}`;
 
       require.undef(failedId);
       require.config(conf);
       return requirePromise([`${moduleName}`]).catch(err => {
-        // Next, if this also errors, we try the full path
-        conf.paths[moduleName] = `${packageRoot}${pathGuess}`;
+        // Next, if this also errors, we the root
+        // and let the CDN decide
+        conf.paths[moduleName] = `${packageRoot}?`; // NOTE: the `?` is added to avoid require appending a .js
         require.undef(failedId);
         require.config(conf);
       });

--- a/packages/voila/src/loader.ts
+++ b/packages/voila/src/loader.ts
@@ -85,7 +85,8 @@ export function requireLoader(
         moduleName,
         moduleVersion
       );
-      conf.paths[moduleName] = packageRoot;
+      conf.paths[moduleName] = `${packageRoot}?`; // NOTE: the `?` is added to avoid require appending a .js
+
       require.undef(failedId);
       require.config(conf);
       return requirePromise([`${moduleName}`]).catch(err => {


### PR DESCRIPTION
## References

Fixes #1128 
Fixes: https://github.com/finos/perspective/issues/1773

## Code changes
First try the base package path. The CDN should be smart enough to resolve this to the `browser` or `main` fields of the packages `package.json`, e.g. from unpkg docs:

<img width="653" alt="Screen Shot 2022-05-07 at 11 47 06 PM" src="https://user-images.githubusercontent.com/3105306/167280930-db197d50-80b6-4502-9299-9c25997ebe0c.png">


jsdelivr does the same thing as here

If this fails, we default to the existing behavior.

## User-facing changes

Should have greater extension compatibility.

## Backwards-incompatible changes

Should be none
