### PR TITLE
adding nbextension path to voila config object

### DIFF
--- a/voila/app.py
+++ b/voila/app.py
@@ -131,6 +131,7 @@ class Voila(Application):
         'base_url': 'Voila.base_url',
         'server_url': 'Voila.server_url',
         'enable_nbextensions': 'VoilaConfiguration.enable_nbextensions',
+        'nbextensions_path': 'VoilaConfiguration.nbextensions_path',
         'show_tracebacks': 'VoilaConfiguration.show_tracebacks',
         'preheat_kernel': 'VoilaConfiguration.preheat_kernel',
         'pool_size': 'VoilaConfiguration.default_pool_size'
@@ -305,6 +306,8 @@ class Voila(Application):
     @property
     def nbextensions_path(self):
         """The path to look for Javascript notebook extensions"""
+        if self.voila_configuration.nbextensions_path:
+            return self.voila_configuration.nbextensions_path
         path = jupyter_path('nbextensions')
         # FIXME: remove IPython nbextensions path after a migration period
         try:

--- a/voila/configuration.py
+++ b/voila/configuration.py
@@ -39,6 +39,7 @@ class VoilaConfiguration(traitlets.config.Configurable):
     theme = Unicode('light', config=True)
     strip_sources = Bool(True, config=True, help='Strip sources from rendered html')
     enable_nbextensions = Bool(False, config=True, help=('Set to True for Voilà to load notebook extensions'))
+    nbextensions_path = Unicode('', config=True, help='Set to override default path provided by Jupyter Server')
 
     file_whitelist = List(
         Unicode(),

--- a/voila/server_extension.py
+++ b/voila/server_extension.py
@@ -94,9 +94,13 @@ def _load_jupyter_server_extension(server_app):
 
     # Serving notebook extensions
     if voila_configuration.enable_nbextensions:
-        # First look into 'nbextensions_path' configuration key (classic notebook)
-        # and fall back to default path for nbextensions (jupyter server).
-        if 'nbextensions_path' in web_app.settings:
+        # First check whether a custom nbextensions_path has been set in
+        # the VoilaConfiguration object, if not, then fall back to
+        # looking into 'nbextensions_path' configuration key (classic notebook)
+        # otherwise fall back to default path for nbextensions (jupyter server).
+        if voila_configuration.nbextensions_path:
+            nbextensions_path = voila_configuration.nbextensions_path
+        elif 'nbextensions_path' in web_app.settings:
             nbextensions_path = web_app.settings['nbextensions_path']
         else:
             nbextensions_path = jupyter_path('nbextensions')


### PR DESCRIPTION

## Code changes

This PR introduces `nbextensions_path` as a configurable value that we can set to override the default Jupyter Server value (as a workaround until Voila moves away entirely from nbextensions to adopt the lab extension system)

## References

### Background on Motivation (credit @SylvainCorlay)
While Voilà is built with JupyterLab components, we use the classic notebook extension system for the widgets, because when Voilà came out, JupyterLab could not use pre-built extensions.
By default, Voilà uses the webpack bundles that are published on npmjs.
But in order to support extensions that have never been published, but are installed locally, we added support for using local notebook extensions.
Jupyter server is the raw server, and it does not come with the notebook frontend, hence it does not have a notion of notebook extensions. As a workaround for applications that have a nbextension path different from the default, we are adding an option `nbextensions_path` to the Voila Configuration object, so that we are not tied to the server default. 

## User-facing changes

introduces a new optional configuration value that users can set to override default server nbextensions path

## Backwards-incompatible changes

N/A
