### PR TITLE
Add Voila configuration option for default kernel environmental variables

### DIFF
--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -323,7 +323,7 @@ Preheated kernels
 ==================
 
 Since Voilà needs to start a new jupyter kernel and execute the requested notebook in this kernel for every connection, this would lead to a long waiting time before the widgets can be displayed in the browser. 
-To reduce this waiting time, especially for the heavy notebooks, users can activate the preheating kernel option of Voilà, this option will enable two features:
+To reduce this waiting time, especially for heavy notebooks, users can activate the preheating kernel option of Voilà, this option will enable two features:
 
 - A pool of kernels is started for each notebook and kept in standby, then the notebook is executed in every kernel of its pool. When a new client requests a kernel, the preheated kernel in this pool is used and another kernel is started asynchronously to refill the pool.
 - The HTML version of the notebook is rendered in each preheated kernel and stored, when a client connects to Voila, under some conditions, the cached HTML is served instead of re-rendering the notebook.
@@ -334,7 +334,15 @@ The preheating kernel option works with any kernel manager, it is deactivated by
 
     voila --preheat_kernel=True --pool_size=5
 
-If the pool size does not match the user's requirements, or some notebooks need to use environment variables..., additional settings are needed.  The easiest way to change these settings is to provide a file named `voila.json` in the same folder containing the notebooks. Settings for preheating kernel ( list of notebooks does not need preheated kernels, number of kernels in pool, refilling delay, environment variables for starting kernel...) can be set under the `VoilaKernelManager` class name.
+The default environment variables for preheated kernels can be set by the `VoilaKernelManager.default_env_variables` setting. For example, this command
+
+.. code-block:: bash
+
+    voila --preheat_kernel=True --VoilaKernelManager.default_env_variables='{"FOO": "BAR"}'
+
+will set the variable "FOO" in all preheated kernels.
+
+If the pool size does not match the user's requirements, or some notebooks need to use specific environment variables..., additional settings are needed.  The easiest way to change these settings is to provide a file named `voila.json` in the same folder containing the notebooks. Settings for preheating kernel ( list of notebooks does not need preheated kernels, number of kernels in pool, refilling delay, environment variables for starting kernel...) can be set under the `VoilaKernelManager` class name.
 
 Here is an example of settings with explanations for preheating kernel option. 
 

--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -435,7 +435,7 @@ Additionally, you can set these with the command:
 
 .. code-block:: bash
 
-    voila --preheat_kernel=True --VoilaConfiguration.default_kernel_env_variables='{"VOILA_WS_PROTOCOL": "wss", "VOILA_APP_PORT": "9000"}'
+    voila --preheat_kernel=True --VoilaKernelManager.default_env_variables='{"VOILA_WS_PROTOCOL":"wss","VOILA_APP_IP":"192.168.1.1"}'
 
 Hiding output and code cells based on cell tags
 ===============================================

--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -410,7 +410,7 @@ In preheating kernel mode, users can prepend with ``wait_for_request`` from ``vo
 
 ``wait_for_request`` will pause the execution of the notebook in the preheated kernel at this cell and wait for an actual user to connect to Voilà, set the request info environment variables and then continue the execution of the remaining cells.
 
-If the Voilà websocket handler is not started with the default protocol (`ws`), the default IP address (`127.0.0.1`) the default port (`8866`) or with url suffix, users need to provide these values through the environment variables ``VOILA_WS_PROTOCOL``, ``VOILA_APP_IP``, ``VOILA_APP_PORT`` and ``VOILA_WS_BASE_URL``. The easiest way is to set these variables in the `voila.json` configuration file, for example:
+If the Voilà websocket handler is not started with the default protocol (`ws`), the default IP address (`127.0.0.1`) the default port (`8866`) or with url suffix, users need to provide these values through the environment variables ``VOILA_WS_PROTOCOL``, ``VOILA_APP_IP``, ``VOILA_APP_PORT`` and ``VOILA_WS_BASE_URL``. One way to set these variables is in the `voila.json` configuration file, for example:
 
 .. code-block:: python
 
@@ -430,6 +430,12 @@ If the Voilà websocket handler is not started with the default protocol (`ws`),
       ...
       }
    }
+
+Additionally, you can set these with the command:
+
+.. code-block:: bash
+
+    voila --preheat_kernel=True --VoilaConfiguration.default_kernel_env_variables='{"VOILA_WS_PROTOCOL": "wss", "VOILA_APP_PORT": "9000"}'
 
 Hiding output and code cells based on cell tags
 ===============================================

--- a/tests/app/preheat_default_kernel_env_test.py
+++ b/tests/app/preheat_default_kernel_env_test.py
@@ -1,0 +1,35 @@
+import asyncio
+import os
+
+import pytest
+
+
+@pytest.fixture()
+def voila_args_extra():
+    return ['--VoilaConfiguration.default_kernel_env_variables={"FOO": "BAR"}']
+
+
+@pytest.fixture
+def preheat_mode():
+    return True
+
+
+@pytest.fixture
+def voila_notebook(notebook_directory):
+    return os.path.join(notebook_directory, 'preheat', 'default_env_variables.ipynb')
+
+
+NOTEBOOK_EXECUTION_TIME = 2
+
+
+async def send_request(sc, url, wait=0):
+    await asyncio.sleep(wait)
+    response = await sc.fetch(url)
+    return response.body.decode('utf-8')
+
+
+async def test_default_kernel_env_variable(http_server_client, base_url):
+    html_text = await send_request(sc=http_server_client,
+                                   url=base_url,
+                                   wait=NOTEBOOK_EXECUTION_TIME + 1)
+    assert 'BAR' in html_text

--- a/tests/app/preheat_default_kernel_env_test.py
+++ b/tests/app/preheat_default_kernel_env_test.py
@@ -6,7 +6,7 @@ import pytest
 
 @pytest.fixture()
 def voila_args_extra():
-    return ['--VoilaConfiguration.default_kernel_env_variables={"FOO": "BAR"}']
+    return ['--VoilaKernelManager.default_env_variables={"FOO": "BAR"}']
 
 
 @pytest.fixture

--- a/tests/notebooks/preheat/default_env_variables.ipynb
+++ b/tests/notebooks/preheat/default_env_variables.ipynb
@@ -1,0 +1,36 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7efe3e8f-4b8d-4fd3-99d1-b06d79b88ae2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "time.sleep(2)\n",
+    "print('hello world')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "782377cd-2bc0-4d0d-8b63-74dcb7e9d645",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.getenv('FOO')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.10.5 ('voila')",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/voila/app.py
+++ b/voila/app.py
@@ -20,6 +20,7 @@ import socket
 import webbrowser
 import errno
 import random
+from typing import Dict as TypeDict
 
 try:
     from urllib.parse import urljoin
@@ -426,10 +427,12 @@ class Voila(Application):
         self.contents_manager = LargeFileManager(parent=self)
         preheat_kernel: bool = self.voila_configuration.preheat_kernel
         pool_size: int = self.voila_configuration.default_pool_size
+        kernel_env_variables: TypeDict[str, str] = self.voila_configuration.default_kernel_env_variables
         kernel_manager_class = voila_kernel_manager_factory(
             self.voila_configuration.multi_kernel_manager_class,
             preheat_kernel,
-            pool_size
+            pool_size,
+            kernel_env_variables,
         )
         self.kernel_manager = kernel_manager_class(
             parent=self,

--- a/voila/app.py
+++ b/voila/app.py
@@ -20,7 +20,6 @@ import socket
 import webbrowser
 import errno
 import random
-from typing import Dict as TypeDict
 
 try:
     from urllib.parse import urljoin
@@ -427,12 +426,10 @@ class Voila(Application):
         self.contents_manager = LargeFileManager(parent=self)
         preheat_kernel: bool = self.voila_configuration.preheat_kernel
         pool_size: int = self.voila_configuration.default_pool_size
-        kernel_env_variables: TypeDict[str, str] = self.voila_configuration.default_kernel_env_variables
         kernel_manager_class = voila_kernel_manager_factory(
             self.voila_configuration.multi_kernel_manager_class,
             preheat_kernel,
             pool_size,
-            kernel_env_variables,
         )
         self.kernel_manager = kernel_manager_class(
             parent=self,

--- a/voila/configuration.py
+++ b/voila/configuration.py
@@ -123,3 +123,12 @@ class VoilaConfiguration(traitlets.config.Configurable):
         help="""Size of pre-heated kernel pool for each notebook. Zero or negative number means disabled.
         """
     )
+
+    default_kernel_env_variables = Dict(
+        {},
+        config=True,
+        help='''Default environmental variables for kernels
+        Example setting variables used by wait_for_request() with preheated kernels:
+        --VoilaConfiguration.default_kernel_env_variables='{"VOILA_WS_PROTOCOL": "wss", "VOILA_APP_PORT": "9000"}'
+        ''',
+    )

--- a/voila/configuration.py
+++ b/voila/configuration.py
@@ -123,12 +123,3 @@ class VoilaConfiguration(traitlets.config.Configurable):
         help="""Size of pre-heated kernel pool for each notebook. Zero or negative number means disabled.
         """
     )
-
-    default_kernel_env_variables = Dict(
-        {},
-        config=True,
-        help='''Default environmental variables for kernels
-        Example setting variables used by wait_for_request() with preheated kernels:
-        --VoilaConfiguration.default_kernel_env_variables='{"VOILA_WS_PROTOCOL": "wss", "VOILA_APP_PORT": "9000"}'
-        ''',
-    )

--- a/voila/voila_kernel_manager.py
+++ b/voila/voila_kernel_manager.py
@@ -28,7 +28,12 @@ async def wait_before(delay: float, aw: Awaitable) -> Awaitable:
     return await aw
 
 
-def voila_kernel_manager_factory(base_class: Type[T], preheat_kernel: bool, default_pool_size: int) -> T:
+def voila_kernel_manager_factory(
+    base_class: Type[T],
+    preheat_kernel: bool,
+    default_pool_size: int,
+    default_kernel_env_variables: TypeDict[str, str],
+) -> T:
     """
     Decorator used to make a normal kernel manager compatible with pre-heated
     kernel system.
@@ -41,6 +46,10 @@ def voila_kernel_manager_factory(base_class: Type[T], preheat_kernel: bool, defa
     Args:
         - base_class (Type[T]): The kernel manager class
         - preheat_kernel (Bool): Flag to decorate the input class
+        - default_pool_size (int): Size of pre-heated kernel pool for each notebook.
+            Zero or negative number means disabled
+        - default_kernel_env_variables (dict[str, str]): Environmental variables to pass
+            to kernel by default.
 
     Returns:
         T: Decorated class
@@ -85,7 +94,12 @@ def voila_kernel_manager_factory(base_class: Type[T], preheat_kernel: bool, defa
 
             @default('kernel_pools_config')
             def _kernel_pools_config(self):
-                return {'default': {'pool_size': max(default_pool_size, 0), 'kernel_env_variables': {}}}
+                return {
+                    'default': {
+                        'pool_size': max(default_pool_size, 0),
+                        'kernel_env_variables': default_kernel_env_variables,
+                    }
+                }
 
             def __init__(self, **kwargs):
 

--- a/voila/voila_kernel_manager.py
+++ b/voila/voila_kernel_manager.py
@@ -28,12 +28,7 @@ async def wait_before(delay: float, aw: Awaitable) -> Awaitable:
     return await aw
 
 
-def voila_kernel_manager_factory(
-    base_class: Type[T],
-    preheat_kernel: bool,
-    default_pool_size: int,
-    default_kernel_env_variables: TypeDict[str, str],
-) -> T:
+def voila_kernel_manager_factory(base_class: Type[T], preheat_kernel: bool, default_pool_size: int) -> T:
     """
     Decorator used to make a normal kernel manager compatible with pre-heated
     kernel system.
@@ -48,8 +43,6 @@ def voila_kernel_manager_factory(
         - preheat_kernel (Bool): Flag to decorate the input class
         - default_pool_size (int): Size of pre-heated kernel pool for each notebook.
             Zero or negative number means disabled
-        - default_kernel_env_variables (dict[str, str]): Environmental variables to pass
-            to kernel by default.
 
     Returns:
         T: Decorated class
@@ -82,6 +75,13 @@ def voila_kernel_manager_factory(
                 variables used to start kernel''',
             )
 
+            default_env_variables = Dict(
+                {},
+                config=True,
+                help='''Default environmental variables for kernels
+                ''',
+            )
+
             preheat_blacklist = List([],
                                      config=True,
                                      help='List of notebooks which do not use pre-heated kernel.')
@@ -97,7 +97,7 @@ def voila_kernel_manager_factory(
                 return {
                     'default': {
                         'pool_size': max(default_pool_size, 0),
-                        'kernel_env_variables': default_kernel_env_variables,
+                        'kernel_env_variables': self.default_env_variables,
                     }
                 }
 


### PR DESCRIPTION
Currently, to use [partially pre-rendered notebooks](https://voila.readthedocs.io/en/stable/customize.html#partially-pre-render-notebook) a user may have to set environmental variables in notebook kernels to access the correct websocket address.

The docs give the example of using `voila.json` to set these. However, for some deployment platforms these values (e.g. base_url or port) may not be known ahead of time or differ between deployments. Having a command line option provides easier passing of env variables (as opposed to modifying `voila.json` in-place).


## Code changes

A `default_kernel_env_variables` attribute is added to `VoilaConfiguration`, which is then passed to the default `kernel_pools_config` of `VoilaKernelManager`.


