### PR TITLE
Add Voila app port to kernel env

### DIFF
--- a/tests/app/preheat_with_query_string_test.py
+++ b/tests/app/preheat_with_query_string_test.py
@@ -15,13 +15,12 @@ def using_server_url(request):
 
 
 @pytest.fixture()
-def voila_args_extra(using_server_url, using_base_url):
-    return using_server_url + using_base_url
+def voila_args_extra(http_server_port, using_server_url, using_base_url):
+    return [f'--port={http_server_port[-1]}'] + using_server_url + using_base_url
 
 
 @pytest.fixture
-def preheat_mode(http_server_port):
-    os.environ['VOILA_APP_PORT'] = str(http_server_port[-1])
+def preheat_mode():
     return True
 
 

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -187,6 +187,7 @@ class VoilaHandler(BaseVoilaHandler):
             kernel_env[ENV_VARIABLE.VOILA_PREHEAT] = 'False'
             kernel_env[ENV_VARIABLE.VOILA_BASE_URL] = self.base_url
             kernel_env[ENV_VARIABLE.VOILA_SERVER_URL] = self.settings.get('server_url', '/')
+            kernel_env[ENV_VARIABLE.VOILA_APP_PORT] = str(port) if port else ''
             kernel_id = await ensure_async(
                 (
                     self.kernel_manager.start_kernel(

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -187,7 +187,6 @@ class VoilaHandler(BaseVoilaHandler):
             kernel_env[ENV_VARIABLE.VOILA_PREHEAT] = 'False'
             kernel_env[ENV_VARIABLE.VOILA_BASE_URL] = self.base_url
             kernel_env[ENV_VARIABLE.VOILA_SERVER_URL] = self.settings.get('server_url', '/')
-            kernel_env[ENV_VARIABLE.VOILA_APP_PORT] = str(port) if port else ''
             kernel_id = await ensure_async(
                 (
                     self.kernel_manager.start_kernel(

--- a/voila/voila_kernel_manager.py
+++ b/voila/voila_kernel_manager.py
@@ -202,8 +202,7 @@ def voila_kernel_manager_factory(base_class: Type[T], preheat_kernel: bool, defa
                         kernel_env[key] = kernel_env_variables[key]
                 kernel_env[ENV_VARIABLE.VOILA_BASE_URL] = self.parent.base_url
                 kernel_env[ENV_VARIABLE.VOILA_SERVER_URL] = self.parent.server_url
-                if ENV_VARIABLE.VOILA_APP_PORT not in kernel_env:
-                    kernel_env[ENV_VARIABLE.VOILA_APP_PORT] = str(self.parent.port)
+                kernel_env[ENV_VARIABLE.VOILA_APP_PORT] = str(self.parent.port)
                 kernel_env[ENV_VARIABLE.VOILA_PREHEAT] = 'True'
                 kwargs['env'] = kernel_env
 

--- a/voila/voila_kernel_manager.py
+++ b/voila/voila_kernel_manager.py
@@ -202,6 +202,8 @@ def voila_kernel_manager_factory(base_class: Type[T], preheat_kernel: bool, defa
                         kernel_env[key] = kernel_env_variables[key]
                 kernel_env[ENV_VARIABLE.VOILA_BASE_URL] = self.parent.base_url
                 kernel_env[ENV_VARIABLE.VOILA_SERVER_URL] = self.parent.server_url
+                if ENV_VARIABLE.VOILA_APP_PORT not in kernel_env:
+                    kernel_env[ENV_VARIABLE.VOILA_APP_PORT] = str(self.parent.port)
                 kernel_env[ENV_VARIABLE.VOILA_PREHEAT] = 'True'
                 kwargs['env'] = kernel_env
 


### PR DESCRIPTION
Similar to https://github.com/voila-dashboards/voila/pull/1141, which added `VOILA_SERVER_URL` to the kernel env, this adds `VOILA_APP_PORT`.

The purpose is to make using preheated kernels with `wait_for_request()` easier when not using the default port.