### PR TITLE
Cleanup exporter

### DIFF
--- a/voila/exporter.py
+++ b/voila/exporter.py
@@ -84,20 +84,8 @@ class VoilaExporter(HTMLExporter):
         highlight_code = self.filters.get('highlight_code', Highlight2HTML(pygments_lexer=lexer, parent=self))
         self.register_filter('highlight_code', highlight_code)
 
-        # NOTE: we don't call HTML or TemplateExporter' from_notebook_node
         nb_copy, resources = super(TemplateExporter, self).from_notebook_node(nb, resources, **kw)
-        resources.setdefault('raw_mimetypes', self.raw_mimetypes)
-        resources['global_content_filter'] = {
-                'include_code': not self.exclude_code_cell,
-                'include_markdown': not self.exclude_markdown,
-                'include_raw': not self.exclude_raw,
-                'include_unknown': not self.exclude_unknown,
-                'include_input': not self.exclude_input,
-                'include_output': not self.exclude_output,
-                'include_input_prompt': not self.exclude_input_prompt,
-                'include_output_prompt': not self.exclude_output_prompt,
-                'no_prompt': self.exclude_input_prompt and self.exclude_output_prompt,
-                }
+
         async for output in self.template.generate_async(nb=nb_copy, resources=resources, **extra_context, static_url=self.static_url):
             yield (output, resources)
 


### PR DESCRIPTION
Some code was duplicated from `TemplateExporter.from_notebook_node` that we actually call.

See https://github.com/jupyter/nbconvert/blob/main/nbconvert/exporters/templateexporter.py#L386-L398

Maybe @maartenbreddels knows why this code was around? Or is this a leftover?