### PR TITLE
Fix inifinite  loop in property access

### DIFF
--- a/voila/exporter.py
+++ b/voila/exporter.py
@@ -105,7 +105,7 @@ class VoilaExporter(HTMLExporter):
     def environment(self):
         # enable Jinja async template execution
         self.enable_async = True
-        env = super(type(self), self).environment
+        env = super().environment
         if 'jinja2.ext.do' not in env.extensions:
             env.add_extension('jinja2.ext.do')
         return env


### PR DESCRIPTION
A subclass of VoilaExporter would create an infinite loop with this

```python
class Foo(VoilaExporter):
    pass
```

Causes:
```
RecursionError: maximum recursion depth exceeded while calling a Python object
```
