### PR TITLE
Error logging at runtime if we detect incompatible ipywidgets version

### DIFF
--- a/voila/notebook_renderer.py
+++ b/voila/notebook_renderer.py
@@ -302,6 +302,8 @@ class NotebookRenderer(LoggingConfigurable):
             finally:
                 yield output_cell
 
+        await self.executor.teardown()
+
         await self._cleanup_resources()
 
     async def _cleanup_resources(self):


### PR DESCRIPTION
## References

Log the following error when we detect that the user is not using a compatible ipywidgets version:

```
[Voila] ERROR | This Voila version is only compatible with ipywidgets version 7, though we detected that you are using ipywidgets version 8.0.2
```

This version is evaluated by checking if ipywidgets is being used in the Notebook (at least imported), and the error is shown in the terminal, but does not prevent the app to continue running.