### PR TITLE
Use `ipywidgets` 8 on Binder

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - jupyterlab=3
+  - ipywidgets=8
   - ipyvolume
   - bqplot
   - scipy


### PR DESCRIPTION
<!--
Thanks for contributing to Voilà!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/voila-dashboards/voila/blob/main/CONTRIBUTING.md
-->

## References

Follow-up to https://github.com/voila-dashboards/voila/pull/1046

Currently widgets don't seem to be working on Binder. This is most likely because the base image on Binder already includes ipywidgets 7.

![image](https://user-images.githubusercontent.com/591645/192627195-63c2b116-7979-4a53-915a-42a0c0fee298.png)


<!-- Note issue numbers this pull request addresses. -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Update Binder dependencies.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Should make widgets work on Binder.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!--
For visual changes, include before and after screenshots here.

You will also need to update the reference screenshots for the Galata visual regression tests,
you can do this automatically by commenting "Please update galata references" in the PR.
-->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to Voilà public APIs. -->
