### PR TITLE
Automated Changelog Entry for 0.4.0b0 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.4.0b0
+
+No merged PRs
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.4.0a2
 
 ([Full Changelog](https://github.com/voila-dashboards/voila/compare/v0.4.0a1...82445875ab5e6b2031a05ad15ea0b53b6166a876))
@@ -20,8 +26,6 @@
 ([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2022-09-30&to=2022-10-04&type=c))
 
 [@github-actions](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Agithub-actions+updated%3A2022-09-30..2022-10-04&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2022-09-30..2022-10-04&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AmartinRenou+updated%3A2022-09-30..2022-10-04&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.4.0a1
 


### PR DESCRIPTION
Automated Changelog Entry for 0.4.0b0 on main
```
Python version: 0.4.0b0
npm version: @voila-dashboards/voila-root: 0.1.0
npm workspace versions:
@voila-dashboards/jupyterlab-preview: 2.2.0-beta.0
@voila-dashboards/voila: 0.4.0-beta.0
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/voila-dashboards/voila/releases/tag/untagged-6a12d46b655f4a2001de  |
| Since | v0.4.0a2 |