### PR TITLE
Remove pin on `jupyter_releaser`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ file = "LICENSE"
 dev = [
     "black",
     "hatch",
-    "jupyter_releaser~=0.25",
+    "jupyter_releaser",
 ]
 test = [
     "ipywidgets",


### PR DESCRIPTION
<!--
Thanks for contributing to Voilà!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/voila-dashboards/voila/blob/main/CONTRIBUTING.md
-->

## References

Try removing the pin the dev dependency `jupyter_releaser`.

`jupyter_releaser` is already installed during the `prep-git` release step. This step also runs `pip install -q -e ".[dev,test]"` which could then reinstall an older version of `jupyter_releaser` from PyPI.

Some more context in https://github.com/jupyter-server/jupyter_releaser/issues/438.

<!-- Note issue numbers this pull request addresses. -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

We can try removing the pin on the `jupyter_releaser` `dev` dependency for now to see if it can help with the current `0.4.0rc0` release.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!--
For visual changes, include before and after screenshots here.

You will also need to update the reference screenshots for the Galata visual regression tests,
you can do this automatically by commenting "Please update galata references" in the PR.
-->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to Voilà public APIs. -->
