### PR TITLE
Add upper bound on jupyter_client dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
 ]
 dependencies = [
-    "jupyter_client>=6.1.3,<=7.4.2",
+    "jupyter_client>=6.1.3,<=7.4.1",
     "jupyter_core>=4.11.0",
     "jupyter_server>=1.18,<2.0.0",
     "jupyterlab_server>=2.3.0,<3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
 ]
 dependencies = [
-    "jupyter_client>=6.1.3,<8",
+    "jupyter_client>=6.1.3,<=7.4.2",
     "jupyter_core>=4.11.0",
     "jupyter_server>=1.18,<2.0.0",
     "jupyterlab_server>=2.3.0,<3",


### PR DESCRIPTION
## References

Latest jupyter-client seems to break our tests. We will pin this dependency so we can finally make a release with ipywidgets 8 support.

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!--
For visual changes, include before and after screenshots here.

You will also need to update the reference screenshots for the Galata visual regression tests,
you can do this automatically by commenting "Please update galata references" in the PR.
-->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to Voilà public APIs. -->
