### PR TITLE
Automated Changelog Entry for 0.4.0 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 ### Bugs fixed
 
 - Add upper bound on jupyter_client dependency [#1239](https://github.com/voila-dashboards/voila/pull/1239) ([@martinRenou](https://github.com/martinRenou))
-- Fix inifinite  loop in property access [#1185](https://github.com/voila-dashboards/voila/pull/1185) ([@martinRenou](https://github.com/martinRenou))
+- Fix inifinite loop in property access [#1185](https://github.com/voila-dashboards/voila/pull/1185) ([@martinRenou](https://github.com/martinRenou))
 
 ### Maintenance and upkeep improvements
 
@@ -31,7 +31,7 @@
 - Troubleshoot the check release workflow [#1208](https://github.com/voila-dashboards/voila/pull/1208) ([@jtpio](https://github.com/jtpio))
 - Fix typos [#1198](https://github.com/voila-dashboards/voila/pull/1198) ([@kianmeng](https://github.com/kianmeng))
 - Migrate to `hatch` [#1197](https://github.com/voila-dashboards/voila/pull/1197) ([@jtpio](https://github.com/jtpio))
-- Fix CI  [#1193](https://github.com/voila-dashboards/voila/pull/1193) ([@trungleduc](https://github.com/trungleduc))
+- Fix CI [#1193](https://github.com/voila-dashboards/voila/pull/1193) ([@trungleduc](https://github.com/trungleduc))
 - Troubleshoot failing `macos` check on CI [#1191](https://github.com/voila-dashboards/voila/pull/1191) ([@jtpio](https://github.com/jtpio))
 - Bump terser from 4.8.0 to 4.8.1 [#1174](https://github.com/voila-dashboards/voila/pull/1174) ([@dependabot](https://github.com/dependabot))
 - Update nbconvert pinning [#1161](https://github.com/voila-dashboards/voila/pull/1161) ([@martinRenou](https://github.com/martinRenou))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,53 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.4.0
+
+([Full Changelog](https://github.com/voila-dashboards/voila/compare/@voila-dashboards/jupyterlab-preview@2.1.6...b300e144f58b885cf8477b60cdabe024cb82ad01))
+
+### Enhancements made
+
+- Render read-only notebook [#1181](https://github.com/voila-dashboards/voila/pull/1181) ([@trungleduc](https://github.com/trungleduc))
+- Add Voila app port to kernel env [#1176](https://github.com/voila-dashboards/voila/pull/1176) ([@dcnadler](https://github.com/dcnadler))
+- Add Voila configuration option for default kernel environmental variables [#1175](https://github.com/voila-dashboards/voila/pull/1175) ([@dcnadler](https://github.com/dcnadler))
+- Update nbconvert pinning [#1161](https://github.com/voila-dashboards/voila/pull/1161) ([@martinRenou](https://github.com/martinRenou))
+- reenable prelaunch-hook [#724](https://github.com/voila-dashboards/voila/pull/724) ([@timkpaine](https://github.com/timkpaine))
+
+### Bugs fixed
+
+- Add upper bound on jupyter_client dependency [#1239](https://github.com/voila-dashboards/voila/pull/1239) ([@martinRenou](https://github.com/martinRenou))
+- Fix inifinite  loop in property access [#1185](https://github.com/voila-dashboards/voila/pull/1185) ([@martinRenou](https://github.com/martinRenou))
+
+### Maintenance and upkeep improvements
+
+- Update nbclient [#1234](https://github.com/voila-dashboards/voila/pull/1234) ([@martinRenou](https://github.com/martinRenou))
+- Remove pin on `jupyter_releaser` [#1232](https://github.com/voila-dashboards/voila/pull/1232) ([@jtpio](https://github.com/jtpio))
+- Update nbclient pinning [#1224](https://github.com/voila-dashboards/voila/pull/1224) ([@martinRenou](https://github.com/martinRenou))
+- Bump d3-color from 3.0.1 to 3.1.0 [#1221](https://github.com/voila-dashboards/voila/pull/1221) ([@dependabot](https://github.com/dependabot))
+- Remove extra_requires [#1215](https://github.com/voila-dashboards/voila/pull/1215) ([@martinRenou](https://github.com/martinRenou))
+- Couple of ui-tests maintenance changes [#1214](https://github.com/voila-dashboards/voila/pull/1214) ([@martinRenou](https://github.com/martinRenou))
+- Use `ipywidgets` 8 on Binder [#1210](https://github.com/voila-dashboards/voila/pull/1210) ([@jtpio](https://github.com/jtpio))
+- Troubleshoot the check release workflow [#1208](https://github.com/voila-dashboards/voila/pull/1208) ([@jtpio](https://github.com/jtpio))
+- Fix typos [#1198](https://github.com/voila-dashboards/voila/pull/1198) ([@kianmeng](https://github.com/kianmeng))
+- Migrate to `hatch` [#1197](https://github.com/voila-dashboards/voila/pull/1197) ([@jtpio](https://github.com/jtpio))
+- Fix CI  [#1193](https://github.com/voila-dashboards/voila/pull/1193) ([@trungleduc](https://github.com/trungleduc))
+- Troubleshoot failing `macos` check on CI [#1191](https://github.com/voila-dashboards/voila/pull/1191) ([@jtpio](https://github.com/jtpio))
+- Bump terser from 4.8.0 to 4.8.1 [#1174](https://github.com/voila-dashboards/voila/pull/1174) ([@dependabot](https://github.com/dependabot))
+- Update nbconvert pinning [#1161](https://github.com/voila-dashboards/voila/pull/1161) ([@martinRenou](https://github.com/martinRenou))
+- feat: support for ipywidgets 8 [#1046](https://github.com/voila-dashboards/voila/pull/1046) ([@mariobuikhuizen](https://github.com/mariobuikhuizen))
+
+### Documentation improvements
+
+- Update Google App Engine deploy docs [#1180](https://github.com/voila-dashboards/voila/pull/1180) ([@trungleduc](https://github.com/trungleduc))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2022-07-18&to=2022-10-26&type=c))
+
+[@alkasm](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Aalkasm+updated%3A2022-07-18..2022-10-26&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ablink1073+updated%3A2022-07-18..2022-10-26&type=Issues) | [@bnavigator](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Abnavigator+updated%3A2022-07-18..2022-10-26&type=Issues) | [@dcnadler](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Adcnadler+updated%3A2022-07-18..2022-10-26&type=Issues) | [@dependabot](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Adependabot+updated%3A2022-07-18..2022-10-26&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Agithub-actions+updated%3A2022-07-18..2022-10-26&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajasongrout+updated%3A2022-07-18..2022-10-26&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2022-07-18..2022-10-26&type=Issues) | [@kianmeng](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Akianmeng+updated%3A2022-07-18..2022-10-26&type=Issues) | [@mariobuikhuizen](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Amariobuikhuizen+updated%3A2022-07-18..2022-10-26&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AmartinRenou+updated%3A2022-07-18..2022-10-26&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3ASylvainCorlay+updated%3A2022-07-18..2022-10-26&type=Issues) | [@timkpaine](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Atimkpaine+updated%3A2022-07-18..2022-10-26&type=Issues) | [@trungleduc](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Atrungleduc+updated%3A2022-07-18..2022-10-26&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.4.0rc1
 
 ([Full Changelog](https://github.com/voila-dashboards/voila/compare/@voila-dashboards/jupyterlab-preview@2.2.0-rc.0...7c0ed278574d64a9abe39039ab2249262e41ceaa))
@@ -19,8 +66,6 @@
 ([GitHub contributors page for this release](https://github.com/voila-dashboards/voila/graphs/contributors?from=2022-10-11&to=2022-10-25&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ablink1073+updated%3A2022-10-11..2022-10-25&type=Issues) | [@bnavigator](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Abnavigator+updated%3A2022-10-11..2022-10-25&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Agithub-actions+updated%3A2022-10-11..2022-10-25&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Ajtpio+updated%3A2022-10-11..2022-10-25&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3AmartinRenou+updated%3A2022-10-11..2022-10-25&type=Issues) | [@trungleduc](https://github.com/search?q=repo%3Avoila-dashboards%2Fvoila+involves%3Atrungleduc+updated%3A2022-10-11..2022-10-25&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.4.0rc0
 


### PR DESCRIPTION
Automated Changelog Entry for 0.4.0 on main
```
Python version: 0.4.0
npm version: @voila-dashboards/voila-root: 0.1.0
npm workspace versions:
@voila-dashboards/jupyterlab-preview: 2.2.0
@voila-dashboards/voila: 0.4.0
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/voila-dashboards/voila/releases/tag/untagged-04cb6bf5ef8839c540ce  |
| Since Last Stable | true |