### PR TITLE
Install function for custom templates, template docs update

### DIFF
--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -106,101 +106,28 @@ A few example voila/nbconvert template projects are:
 * https://github.com/voila-dashboards/voila-vuetify
 
 
-Where are Voilà templates located?
-----------------------------------
+Install a custom template
+-------------------------
 
-All Voilà templates are stored as folders with particular configuration/template files inside.
-These folders can exist in the standard Jupyter configuration locations, in a folder called ``voila/templates``.
-For example:
+Suppose you created a custom template called ``mytemplate``, defined in a set of
+directories located on your machine at ``/path/to/share/``.
+You can install the custom template for use with Voilà like so:
 
-.. code-block:: bash
+.. code-block:: python
 
-   ~/.local/share/jupyter/voila/templates
-   ~/path/to/env/dev/share/jupyter/voila/templates
-   /usr/local/share/jupyter/voila/templates
-   /usr/share/jupyter/voila/templates
+   from voila.paths import install_custom_template
 
-Voilà will search these locations for a folder, one per template, where
-the folder name defines the template name.
+   custom_template_name = 'mytemplate'
+   share_path = '/path/to/share/'
 
-The Voilà template structure
-----------------------------
+   install_custom_template(share_path, custom_template_name)
 
-Within each template folder, you can provide your own nbconvert templates, static
-files, and HTML templates (for pages such as a 404 error). For example, here is
-the folder structure of the base Voilà template (called "default"):
-
-.. code-block:: bash
-
-    tree path/to/env/share/jupyter/voila/templates/default/
-    ├── nbconvert_templates
-    │   ├── base.tpl
-    │   └── voila.tpl
-    └── templates
-        ├── 404.html
-        ├── error.html
-        ├── page.html
-        └── tree.html
-
-**To customize the nbconvert template**, store it in a folder called ``templatename/nbconvert_templates/voila.tpl``.
-In the case of the default template, we also provide a ``base.tpl`` that our custom template uses as a base.
-The name ``voila.tpl`` is special - you cannot name your custom nbconvert something else.
-
-**To customize the HTML page templates**, store them in a folder called ``templatename/templates/<name>.html``.
-These are files that Voilà can serve as standalone HTML (for example, the ``tree.html`` template defines how
-folders/files are displayed in ``localhost:8866/voila/tree``). You can override the defaults by providing your
-own HTML files of the same name.
-
-**To configure your Voilà template**, you should add a ``config.json`` file to the root of your template
-folder.
+This function will try to symlink (preferred) or copy (fallback option) the
+directories defining ``mytemplate`` to the paths where voilà keeps other
+templates.
 
 .. todo: Add information on config.json
 
-
-An example custom template
---------------------------
-
-To show how to create your own custom template, let's create our own nbconvert template.
-We'll have two goals:
-
-1. Add an ``<h1>`` header displaying "Our awesome template" to the Voilà dashboard.
-2. Add a custom 404.html page that displays an image.
-
-First, we'll create a folder in ``~/.local/share/jupyter/voila/templates`` called ``mytemplate``::
-
-    mkdir ~/.local/share/jupyter/voila/templates/mytemplate
-    cd ~/.local/share/jupyter/voila/templates/mytemplate
-
-Next, we'll copy over the base template files for Voilà, which we'll modify::
-
-    cp -r path/to/env/share/jupyter/voila/templates/default/nbconvert_templates ./
-    cp -r path/to/env/share/jupyter/voila/templates/default/templates ./
-
-We should now have a folder structure like this:
-
-.. code-block:: bash
-
-    tree .
-    ├── nbconvert_templates
-    │   ├── base.tpl
-    │   └── voila.tpl
-    └── templates
-        ├── 404.html
-        ├── error.html
-        ├── page.html
-        └── tree.html
-
-Now, we'll edit ``nbconvert_templates/voila.tpl`` to include a custom H1 header.
-
-As well as ``templates/tree.html`` to include an image.
-
-Finally, we can tell Voilà to use this custom template the next time we use it on
-a Jupyter notebook by using the name of the folder in the ``--template`` parameter::
-
-    voila mynotebook.ipynb --template=mytemplate
-
-
-The result should be a Voilà dashboard with your custom modifications made!
 
 Voilà template cookiecutter
 -----------------------------

--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -110,7 +110,7 @@ Install a custom template
 -------------------------
 
 Suppose you created a custom template called ``mytemplate``, defined in a set of
-directories located on your machine at ``/path/to/share/``.
+directories located on your machine at ``/path/to/custom/``.
 You can install the custom template for use with Voilà like so:
 
 .. code-block:: python
@@ -118,13 +118,15 @@ You can install the custom template for use with Voilà like so:
    from voila.paths import install_custom_template
 
    custom_template_name = 'mytemplate'
-   share_path = '/path/to/share/'
+   share_path = '/path/to/custom/'
 
    install_custom_template(share_path, custom_template_name)
 
 This function will try to symlink (preferred) or copy (fallback option) the
 directories defining ``mytemplate`` to the paths where voilà keeps other
-templates.
+templates. ``share_path`` should contain the directories
+``share/jupyter/nbconvert/templates/mytemplate`` and
+``share/jupyter/voila/templates/mytemplate``.
 
 .. todo: Add information on config.json
 


### PR DESCRIPTION
<!--
Thanks for contributing to Voilà!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/voila-dashboards/voila/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses. -->
This PR addresses #827, as well as spacetelescope/jdaviz#1729.
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

This PR introduces a convenience function for installing custom templates, called `install_custom_template`. A user specifies a path to a custom template's directory structure and the name of the custom template. The custom template is then symlinked (preferred) or copied (fallback option) to the same directory where the voila `base` template is located. By default, this function does not overwrite existing templates. Also by default, `install_custom_template` will ignore any ``share/`` dirs in the current working directory (so if you run `install_custom_template` in your local `voila` repo, it won't install your custom template in the voila repo's ``share/`` dir.

Background: this PR was motivated by work on spacetelescope/jdaviz#1729. jdaviz, among other tools, contains a custom voilà template which gets installed with the package. We had to [carefully symlink or copy the template files from within our `setup.py`](https://github.com/spacetelescope/jdaviz/blob/main/setup.py#L123-L164) in order to make the jdaviz custom template available for voilà. In spacetelescope/jdaviz#1792 I developed the functions in this PR, and we realized they might belong upstream in voilà. If this PR is merged, it supersedes spacetelescope/jdaviz#1792.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
I've edited docs page on custom templates, mostly by removing out-of-date content.
<!--
For visual changes, include before and after screenshots here.

You will also need to update the reference screenshots for the Galata visual regression tests,
you can do this automatically by commenting "Please update galata references" in the PR.
-->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to Voilà public APIs. -->
None.