### PR TITLE
Correct "strip_source" in README to "strip_sources"

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ callbacks to changes in Jupyter interactive widgets.
 
 - By default, Voilà disallows execute requests from the front-end, preventing
   execution of arbitrary code.
-- By default, Voilà runs with the `strip_source` option, which strips out the
+- By default, Voilà runs with the `strip_sources` option, which strips out the
   input cells from the rendered notebook.
 
 ## Installation


### PR DESCRIPTION
Thanks for working on such a great project!

Minor documentation update in the readme. You can see that `strip_sources` is the correct option [here](https://github.com/voila-dashboards/voila/blob/5b10cf6e8ecdf854b5fd6db92e26b944110f1840/voila/configuration.py#L40) (and in [other places throughout the code](https://github.com/voila-dashboards/voila/search?q=strip_sources)).