### PR TITLE
Reveal template: Use proper routine for including JS asset

### DIFF
--- a/share/jupyter/voila/templates/reveal/index.html.j2
+++ b/share/jupyter/voila/templates/reveal/index.html.j2
@@ -5,11 +5,7 @@
 
 {%- block html_head_js -%}
   {%- block html_head_js_requirejs -%}
-  <script
-    src="{{resources.base_url}}voila/templates/reveal/static/require.min.js"
-    integrity="sha256-Ae2Vz/4ePdIu6ZyI/5ZGsYnb+m0JlOmKPjt6XZ9JJkA="
-    crossorigin="anonymous">
-  </script>
+  {{ resources.include_js("static/require.min.js") }}
   {%- endblock html_head_js_requirejs -%}
   {%- block html_head_js_logs -%}
     {{ log.js() }}


### PR DESCRIPTION
This fixes support for the reveal template in Voici (and nbconvert?)