### PR TITLE
Clean up the check release workflow

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -20,14 +20,6 @@ jobs:
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
-      - name: Upgrade packaging dependencies
-        run: |
-          pip install --upgrade jupyter-packaging~=0.10 --user
-
-      - name: Install Dependencies
-        run: |
-          pip install .
-
       - name: Check Release
         uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v2
         with:


### PR DESCRIPTION
<!--
Thanks for contributing to Voilà!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/voila-dashboards/voila/blob/main/CONTRIBUTING.md
-->

## References

With Releaser v2 it should be possible to make a Voila release without installing the `voila` package, and without `jupyter-packaging` (Voila uses `hatch` now)

<!-- Note issue numbers this pull request addresses. -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Clean up `check_release.yml`. This should avoid some potential issues that could arise during a real release but not with the check release.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!--
For visual changes, include before and after screenshots here.

You will also need to update the reference screenshots for the Galata visual regression tests,
you can do this automatically by commenting "Please update galata references" in the PR.
-->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to Voilà public APIs. -->
