### PR TITLE
Remove unused `_get_query_string` function

### DIFF
--- a/voila/utils.py
+++ b/voila/utils.py
@@ -104,12 +104,6 @@ def get_page_config(base_url, settings, log):
     return page_config
 
 
-async def _get_query_string(ws_url: str) -> Awaitable:
-    async with websockets.connect(ws_url) as websocket:
-        qs = await websocket.recv()
-    return qs
-
-
 def wait_for_request(url: str = None) -> str:
     """Helper function to pause the execution of notebook and wait for
     the pre-heated kernel to be used and all request info is added to


### PR DESCRIPTION
<!--
Thanks for contributing to Voilà!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/voila-dashboards/voila/blob/main/CONTRIBUTING.md
-->

## References

This `_get_query_string` util function appears to not be used anywhere else in the code base.

It is also prefixed with a `_` which suggests it was as a private utility function within the module before.

<!-- Note issue numbers this pull request addresses. -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Remove unused code.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!--
For visual changes, include before and after screenshots here.

You will also need to update the reference screenshots for the Galata visual regression tests,
you can do this automatically by commenting "Please update galata references" in the PR.
-->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to Voilà public APIs. -->
