### PR TITLE
Set `cell-index` attribute as a string

### DIFF
--- a/share/jupyter/voila/templates/classic/index.html.j2
+++ b/share/jupyter/voila/templates/classic/index.html.j2
@@ -66,7 +66,7 @@
   {%- for cell in nb.cells -%}
     {% set cellloop = loop %}
       {%- block any_cell scoped -%}
-        <div cell-index={{cellloop.index}}>
+        <div cell-index="{{cellloop.index}}">
           {{ super() }}
         </div>
       {%- endblock any_cell -%}

--- a/share/jupyter/voila/templates/lab/index.html.j2
+++ b/share/jupyter/voila/templates/lab/index.html.j2
@@ -95,7 +95,7 @@
     {%- for cell in cell_generator(nb, kernel_id) -%}
       {% set cellloop = loop %}
       {%- block any_cell scoped -%}
-        <div cell-index={{cellloop.index}}>
+        <div cell-index="{{cellloop.index}}">
           <script>
             voila_process({{ cellloop.index }}, {{ cell_count }})
           </script>

--- a/share/jupyter/voila/templates/reveal/index.html.j2
+++ b/share/jupyter/voila/templates/reveal/index.html.j2
@@ -75,19 +75,19 @@
 {% endblock data_priority %}
 
 {%- block codecell -%}
-  <div cell-index={{cellloop.index}}>
+  <div cell-index="{{cellloop.index}}">
     {{ super() }}
   </div>
 {%- endblock codecell -%}
 
 {%- block markdowncell -%}
-  <div cell-index={{cellloop.index}}>
+  <div cell-index="{{cellloop.index}}">
     {{ super() }}
   </div>
 {%- endblock markdowncell -%}
 
 {%- block rawcell -%}
-  <div cell-index={{cellloop.index}}>
+  <div cell-index="{{cellloop.index}}">
     {{ super() }}
   </div>
 {%- endblock rawcell -%}


### PR DESCRIPTION
<!--
Thanks for contributing to Voilà!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/voila-dashboards/voila/blob/main/CONTRIBUTING.md
-->

## References

Currently Voila produces HTML with `cell-index` attributes set to integers:

![image](https://user-images.githubusercontent.com/591645/231489031-4c57a2a7-c868-4f98-8a0a-c301649abecf.png)


This can for example be seen on Binder: https://mybinder.org/v2/gh/voila-dashboards/voila/main?urlpath=voila%2Ftree%2Fnotebooks

However attributes are more commonly set as string.

Also Voici expects a string when looking up these elements here: https://github.com/voila-dashboards/voici/blob/7b8825e10c05e31e4e1731fffbe60ffdc327304e/packages/voici/src/app.ts#L328

```ts
const element = document.querySelector(`[cell-index="${idx + 1}"]`);
```

<!-- Note issue numbers this pull request addresses. -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Update `cell-index` to be a string in the templates.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!--
For visual changes, include before and after screenshots here.

You will also need to update the reference screenshots for the Galata visual regression tests,
you can do this automatically by commenting "Please update galata references" in the PR.
-->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to Voilà public APIs. -->
