### PR TITLE
Inject react-dom in the shared scope

### DIFF
--- a/packages/voila/package.json
+++ b/packages/voila/package.json
@@ -40,7 +40,8 @@
     "@lumino/signaling": "^1.7.2",
     "@lumino/virtualdom": "^1.11.2",
     "@lumino/widgets": "^1.26.2",
-    "react": "^17.0.1"
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",

--- a/packages/voila/src/main.ts
+++ b/packages/voila/src/main.ts
@@ -12,6 +12,9 @@
 
 // Inspired by: https://github.com/jupyterlab/jupyterlab/blob/master/dev_mode/index.js
 
+// Inject some packages in the shared scope
+import 'react-dom';
+
 import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 
 import { VoilaApp } from './app';


### PR DESCRIPTION
## References

Similar to https://github.com/voila-dashboards/voici/pull/67

This fixes support for ipyflex