### PR TITLE
Install yarn<3 in dev env

### DIFF
--- a/docs/source/contribute.rst
+++ b/docs/source/contribute.rst
@@ -31,7 +31,7 @@ First, you need to fork the project. Then setup your environment:
 .. code-block:: bash
 
    # create a new conda environment
-   conda create -n voila -c conda-forge notebook jupyterlab nodejs yarn pip
+   conda create -n voila -c conda-forge notebook jupyterlab nodejs "yarn<3" pip
    conda activate voila
 
    # download voila from your GitHub fork


### PR DESCRIPTION
With yarn v3.6.0, installation fails with:
```
# This file contains the result of Yarn building a package (@voila-dashboards/voila-root@workspace:.)
# Script name: install

lerna notice cli v4.0.0
lerna info versioning independent
lerna info bootstrap root only
Unknown Syntax Error: Unsupported option name ("--mutex").

$ yarn install [--json] [--immutable] [--immutable-cache] [--check-cache] [--inline-builds] [--mode #0]
lerna ERR! yarn install --mutex network:42424 --non-interactive exited 1 in '@voila-dashboards/voila-root'
lerna ERR! yarn install --mutex network:42424 --non-interactive exited 1 in '@voila-dashboards/voila-root'
```