### PR TITLE
Use partial

### DIFF
--- a/voila/notebook_renderer.py
+++ b/voila/notebook_renderer.py
@@ -11,6 +11,7 @@
 import os
 import sys
 import traceback
+from functools import partial
 from typing import Generator, List, Tuple, Union
 
 import nbformat
@@ -150,8 +151,7 @@ class NotebookRenderer(LoggingConfigurable):
         kernel_id: Union[str, None] = None,
         kernel_future=None,
     ) -> Generator:
-        async def inner_kernel_start(nb):
-            return await self._jinja_kernel_start(nb, kernel_id, kernel_future)
+        inner_kernel_start = partial(self._jinja_kernel_start, kernel_id=kernel_id, kernel_future=kernel_future)
 
         def inner_cell_generator(nb, kernel_id):
             return self._jinja_cell_generator(nb, kernel_id)


### PR DESCRIPTION
## Code changes

Use `partial` instead of defining a function.

## User-facing changes

None.

## Backwards-incompatible changes

None.