### PR TITLE
Do not clean up kernel resources after execution

### DIFF
--- a/voila/notebook_renderer.py
+++ b/voila/notebook_renderer.py
@@ -244,8 +244,6 @@ class NotebookRenderer(LoggingConfigurable):
         #  (it seems to be local to our block)
         nb.cells = result.cells
 
-        await self._cleanup_resources()
-
     async def _jinja_cell_generator(self, nb, kernel_id):
         """Generator that will execute a single notebook cell at a time"""
         nb, _ = ClearOutputPreprocessor().preprocess(
@@ -294,12 +292,6 @@ class NotebookRenderer(LoggingConfigurable):
                     ]
             finally:
                 yield output_cell
-
-        await self._cleanup_resources()
-
-    async def _cleanup_resources(self):
-        await ensure_async(self.executor.km.cleanup_resources())
-        await ensure_async(self.executor.kc.stop_channels())
 
     async def load_notebook(self, path):
         model = await ensure_async(self.contents_manager.get(path=path))

--- a/voila/notebook_renderer.py
+++ b/voila/notebook_renderer.py
@@ -244,6 +244,8 @@ class NotebookRenderer(LoggingConfigurable):
         #  (it seems to be local to our block)
         nb.cells = result.cells
 
+        await self._cleanup_resources()
+
     async def _jinja_cell_generator(self, nb, kernel_id):
         """Generator that will execute a single notebook cell at a time"""
         nb, _ = ClearOutputPreprocessor().preprocess(
@@ -292,6 +294,11 @@ class NotebookRenderer(LoggingConfigurable):
                     ]
             finally:
                 yield output_cell
+
+        await self._cleanup_resources()
+
+    async def _cleanup_resources(self):
+        await ensure_async(self.executor.kc.stop_channels())
 
     async def load_notebook(self, path):
         model = await ensure_async(self.contents_manager.get(path=path))


### PR DESCRIPTION
Revert https://github.com/voila-dashboards/voila/pull/969

This should never have been merged. The client still needs the kernel and channels running after execution !

When using a kernel provisionner, this would simply **kill the kernel**