### PR TITLE
Embed all `jupyterlab-manager` plugins

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8]
-        node-version: [16.x]
+        node-version: [18.x]
       fail-fast: false
 
     steps:

--- a/packages/voila/src/main.ts
+++ b/packages/voila/src/main.ts
@@ -25,11 +25,6 @@ import {
 
 //Inspired by: https://github.com/jupyterlab/jupyterlab/blob/master/dev_mode/index.js
 
-const disabled = [
-  '@jupyter-widgets/jupyterlab-manager:plugin',
-  '@jupyter-widgets/jupyterlab-manager:saveWidgetState'
-];
-
 /**
  * The main function
  */
@@ -44,6 +39,9 @@ async function main() {
     require('@jupyterlab/rendermime-extension'),
     require('@jupyterlab/theme-light-extension'),
     require('@jupyterlab/theme-dark-extension'),
+    require('@jupyter-widgets/jupyterlab-manager/lib/plugin').default.filter(
+      (p: any) => p.id !== '@jupyter-widgets/jupyterlab-manager:plugin'
+    ),
     plugins
   ];
 
@@ -101,7 +99,7 @@ async function main() {
   );
   federatedExtensions.forEach((p) => {
     if (p.status === 'fulfilled') {
-      for (const plugin of activePlugins(p.value, disabled)) {
+      for (const plugin of activePlugins(p.value, [])) {
         mods.push(plugin);
       }
     } else {
@@ -115,7 +113,7 @@ async function main() {
   );
   federatedMimeExtensions.forEach((p) => {
     if (p.status === 'fulfilled') {
-      for (const plugin of activePlugins(p.value, disabled)) {
+      for (const plugin of activePlugins(p.value, [])) {
         mimeExtensions.push(plugin);
       }
     } else {

--- a/packages/voila/src/tree.ts
+++ b/packages/voila/src/tree.ts
@@ -26,14 +26,6 @@ import {
   widgetManager
 } from './voilaplugins';
 
-export const TREE_DISABLED_EXTENSIONS = [
-  '@jupyter-widgets/jupyterlab-manager:plugin',
-  '@jupyter-widgets/jupyterlab-manager:saveWidgetState',
-  '@jupyter-widgets/jupyterlab-manager:base-2.0.0',
-  '@jupyter-widgets/jupyterlab-manager:controls-2.0.0',
-  '@jupyter-widgets/jupyterlab-manager:output-1.0.0'
-];
-
 /**
  * The main function
  */
@@ -100,7 +92,7 @@ async function main() {
   );
   federatedExtensions.forEach((p) => {
     if (p.status === 'fulfilled') {
-      for (const plugin of activePlugins(p.value, TREE_DISABLED_EXTENSIONS)) {
+      for (const plugin of activePlugins(p.value, [])) {
         mods.push(plugin);
       }
     } else {
@@ -114,7 +106,7 @@ async function main() {
   );
   federatedMimeExtensions.forEach((p) => {
     if (p.status === 'fulfilled') {
-      for (const plugin of activePlugins(p.value, TREE_DISABLED_EXTENSIONS)) {
+      for (const plugin of activePlugins(p.value, [])) {
         mimeExtensions.push(plugin);
       }
     } else {

--- a/voila/utils.py
+++ b/voila/utils.py
@@ -118,9 +118,10 @@ def get_page_config(base_url, settings, log, voila_configuration: VoilaConfigura
     disabled_extensions = [
         "@voila-dashboards/jupyterlab-preview",
         "@jupyter/collaboration-extension",
+        "@jupyter-widgets/jupyterlab-manager",
     ]
     disabled_extensions.extend(page_config.get("disabledExtensions", []))
-    required_extensions = ["@jupyter-widgets/jupyterlab-manager"]
+    required_extensions = []
     federated_extensions = deepcopy(page_config["federated_extensions"])
 
     page_config["federated_extensions"] = filter_extension(


### PR DESCRIPTION
<!--
Thanks for contributing to Voilà!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/voila-dashboards/voila/blob/main/CONTRIBUTING.md
-->

## References

A patch-level fix for https://github.com/voila-dashboards/voila/issues/1392

## Code changes
 In order to render properly the widgets, Voila needs tokens coming from 4 plugins of `@jupyter-widgets/jupyterlab-manager`:   `managerPlugin`, `baseWidgetsPlugin`, `controlWidgetsPlugin` and `outputWidgetPlugin`. This PR changes the way Voila loads these plugins:

- Before: `Voila` provides a replacement for `managerPlugin`, relies on the federated extensions to load `baseWidgetsPlugin`, `controlWidgetsPlugin` and `outputWidgetPlugin`
 
 - After: `Voila` provides a replacement for `managerPlugin`, embeds directly `baseWidgetsPlugin`, `controlWidgetsPlugin` and `outputWidgetPlugin` 


## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!--
For visual changes, include before and after screenshots here.

You will also need to update the reference screenshots for the Galata visual regression tests,
you can do this automatically by commenting "Please update galata references" in the PR.
-->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to Voilà public APIs. -->
