### PR TITLE
adds ploomber cloud deploy option

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -80,6 +80,20 @@ To specify different options (such as the theme and template), create a
 An example can be found in the
 [voila-demo](https://github.com/maartenbreddels/voila-demo) repository.
 
+### Deployment on Ploomber Cloud
+
+Ploomber Cloud offers a [free deployment](https://platform.ploomber.io) option for
+Voilà apps. Once you create an account and log in, follow these steps:
+
+1. Click on the "NEW" button
+2. In the "Framework" section, click on Voilà
+3. In the "Source code" section, click on "Upload your files"
+4. Upload your `.ipynb` file and `requirements.txt` file
+5. Click on "CREATE"
+6. Wait until deployment finishes. To see your app, click on the "VIEW" button
+
+Full instructions for deploying Voilà apps are available [here.](https://docs.cloud.ploomber.io/en/latest/apps/voila.html)
+
 ### Deployment on Railway
 
 :::{note}


### PR DESCRIPTION
<!--
Thanks for contributing to Voilà!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/voila-dashboards/voila/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses. -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

As discussed with Martin, I'm adding instructions to deploy Voilà apps to Ploomber Cloud.

We also discussed adding a template (similar to [this one](https://github.com/voila-dashboards/voila-railway)), but there's currently no need since users can deploy from a UI. We'll add some customizations soon, so I'll create one once a template is needed.

## Code changes

<!-- Describe the code changes and how they address the issue. -->

None, just documentation changes. Added instructions to deploy Voilà apps on Ploombere Cloud.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!--
For visual changes, include before and after screenshots here.

You will also need to update the reference screenshots for the Galata visual regression tests,
you can do this automatically by commenting "Please update galata references" in the PR.
-->

None.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to Voilà public APIs. -->

None.
