### PR TITLE
Allow for custom kernel_spec_manager class

### DIFF
--- a/docs/customize.md
+++ b/docs/customize.md
@@ -639,3 +639,21 @@ By using the [layout customization system](https://jupyterlab.readthedocs.io/en/
    }
 }
 ```
+
+## Custom kernel_spec_manager class
+
+By default, Voilà uses `jupyter_client`'s KernelSpecManager. To change this class, add the following to your config like so:
+
+```py
+import CustomKernelSpecManager
+
+c.VoilaConfiguration.kernel_spec_manager_class = CustomKernelSpecManager
+```
+
+## Kernel startup_timeout
+
+By default, Voilà's grace period for kernel startup time is 60 seconds. It can be adjusted as such, in seconds
+
+```sh
+voila --VoilaExecutor.startup_timeout=60
+```

--- a/voila/app.py
+++ b/voila/app.py
@@ -168,7 +168,7 @@ class Voila(Application):
         "template": "VoilaConfiguration.template",
         "theme": "VoilaConfiguration.theme",
         "classic_tree": "VoilaConfiguration.classic_tree",
-        "kernel_spec_manager_class": "VoilaConfiguration.kernel_spec_manager_class"
+        "kernel_spec_manager_class": "VoilaConfiguration.kernel_spec_manager_class",
     }
     classes = [VoilaConfiguration, VoilaExecutor, VoilaExporter]
     connection_dir_root = Unicode(
@@ -544,7 +544,9 @@ class Voila(Application):
         # default server_url to base_url
         self.server_url = self.server_url or self.base_url
 
-        self.kernel_spec_manager = self.voila_configuration.kernel_spec_manager_class(parent=self)
+        self.kernel_spec_manager = self.voila_configuration.kernel_spec_manager_class(
+            parent=self
+        )
 
         # we create a config manager that load both the serverconfig and nbconfig (classical notebook)
         read_config_path = [

--- a/voila/app.py
+++ b/voila/app.py
@@ -35,7 +35,6 @@ except ImportError:
 import jinja2
 import tornado.ioloop
 import tornado.web
-from jupyter_client.kernelspec import KernelSpecManager
 from jupyter_core.paths import jupyter_config_path, jupyter_path
 from jupyter_server.base.handlers import FileFindHandler, path_regex
 from jupyter_server.config_manager import recursive_update
@@ -169,6 +168,7 @@ class Voila(Application):
         "template": "VoilaConfiguration.template",
         "theme": "VoilaConfiguration.theme",
         "classic_tree": "VoilaConfiguration.classic_tree",
+        "kernel_spec_manager_class": "VoilaConfiguration.kernel_spec_manager_class"
     }
     classes = [VoilaConfiguration, VoilaExecutor, VoilaExporter]
     connection_dir_root = Unicode(
@@ -544,7 +544,7 @@ class Voila(Application):
         # default server_url to base_url
         self.server_url = self.server_url or self.base_url
 
-        self.kernel_spec_manager = KernelSpecManager(parent=self)
+        self.kernel_spec_manager = self.voila_configuration.kernel_spec_manager_class(parent=self)
 
         # we create a config manager that load both the serverconfig and nbconfig (classical notebook)
         read_config_path = [

--- a/voila/configuration.py
+++ b/voila/configuration.py
@@ -158,6 +158,14 @@ class VoilaConfiguration(traitlets.config.Configurable):
         """,
     )
 
+    kernel_spec_manager_class = Type(
+        config=True,
+        default_value="jupyter_client.kernelspec.KernelSpecManager",
+        klass="jupyter_client.kernelspec.KernelSpecManager",
+        help="""The kernel spec manager class.  Allows for setting a custom kernel spec manager for finding and running kernels
+        """
+    )
+
     http_header_envs = List(
         Unicode(),
         [],

--- a/voila/configuration.py
+++ b/voila/configuration.py
@@ -163,7 +163,7 @@ class VoilaConfiguration(traitlets.config.Configurable):
         default_value="jupyter_client.kernelspec.KernelSpecManager",
         klass="jupyter_client.kernelspec.KernelSpecManager",
         help="""The kernel spec manager class.  Allows for setting a custom kernel spec manager for finding and running kernels
-        """
+        """,
     )
 
     http_header_envs = List(

--- a/voila/execute.py
+++ b/voila/execute.py
@@ -10,7 +10,7 @@
 from nbclient.client import NotebookClient
 from nbclient.exceptions import CellExecutionError
 from nbconvert.preprocessors.clearoutput import ClearOutputPreprocessor
-from traitlets import Bool, Unicode
+from traitlets import Bool, Unicode, Integer
 
 
 def strip_code_cell_warnings(cell):
@@ -48,6 +48,18 @@ class VoilaExecutor(NotebookClient):
         False,
         config=True,
         help=("Whether to send tracebacks to clients on exceptions."),
+    )
+
+    startup_timeout: int = Integer(
+        60,
+        config=True,
+        help=(
+            """
+            The time to wait (in seconds) for the kernel to start.
+            If kernel startup takes longer, a RuntimeError is
+            raised.
+            """
+        ),
     )
 
     def execute(self, nb, resources, km=None):


### PR DESCRIPTION
<!--
Thanks for contributing to Voilà!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/voila-dashboards/voila/blob/main/CONTRIBUTING.md
-->

## References

Resolves #1403 
<!-- Note issue numbers this pull request addresses. -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

I've exposed the app level `kernel_spec_manager` property to the `VoilaConfiguration`.  I've also allowed for the `startup_timeout` property to be set as well for async managers.
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!--
For visual changes, include before and after screenshots here.

You will also need to update the reference screenshots for the Galata visual regression tests,
you can do this automatically by commenting "Please update galata references" in the PR.
-->
N/A

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to Voilà public APIs. -->
N/A