### PR TITLE
Remove duplicate logo in the main docs page

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -379,6 +379,7 @@ For more information, you can also follow [the guide on the nginx blog](https://
 ### Using Apache2 as reverse proxy
 
 Apache can also be used to serve voilà. These Apache modules need to be installed and enabled:
+
 - mod_proxy
 - mod_rewrite
 - mod_proxy_http

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,10 +10,6 @@ Want to turn your Voilà dashboard into a static webpage? Check out [Voici](http
 The combination of [JupyterLite](https://jupyterlite.readthedocs.io) and Voilà
 :::
 
-```{image} voila-logo.svg
-:alt: voila
-```
-
 _From notebooks to standalone web applications and dashboards._
 
 Voilà allows you to convert a Jupyter Notebook into an


### PR DESCRIPTION
The logo is there twice on the main page:

![Screenshot from 2023-11-29 13-42-56](https://github.com/voila-dashboards/voila/assets/21197331/eaf6a424-89d2-4216-9a2a-2717d22c9b64)

The PR remove the second big one