### PR TITLE
enhancement: Allow users to disable the fix_notebook call

### DIFF
--- a/docs/customize.md
+++ b/docs/customize.md
@@ -657,3 +657,11 @@ By default, Voilà's grace period for kernel startup time is 60 seconds. It can 
 ```sh
 voila --VoilaExecutor.startup_timeout=60
 ```
+
+## Have voila attempt to solve a best fit kernel spec
+
+By default, Voilà will attempt to resolve a kernel spec to the best fit, based on the available environments. You can disable this functionality as follows:
+
+```py
+c.VoilaConfiguration.attempt_fix_notebook = False
+```

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -379,6 +379,7 @@ For more information, you can also follow [the guide on the nginx blog](https://
 ### Using Apache2 as reverse proxy
 
 Apache can also be used to serve voilà. These Apache modules need to be installed and enabled:
+
 - mod_proxy
 - mod_rewrite
 - mod_proxy_http

--- a/voila/configuration.py
+++ b/voila/configuration.py
@@ -211,3 +211,9 @@ class VoilaConfiguration(traitlets.config.Configurable):
         help="""The dictionary of extension configuration, this dict is passed to the frontend
         through the PageConfig""",
     )
+
+    attempt_fix_notebook = Bool(
+        True,
+        config=True,
+        help="""Whether or not voila should attempt to fix and resolve a notebooks kernelspec metadata""",
+    )

--- a/voila/notebook_renderer.py
+++ b/voila/notebook_renderer.py
@@ -312,7 +312,8 @@ class NotebookRenderer(LoggingConfigurable):
         __, extension = os.path.splitext(model.get("path", ""))
         if model.get("type") == "notebook":
             notebook = model["content"]
-            notebook = await self.fix_notebook(notebook)
+            if self.voila_configuration.attempt_fix_notebook:
+                notebook = await self.fix_notebook(notebook)
             return notebook
         elif extension in self.voila_configuration.extension_language_mapping:
             language = self.voila_configuration.extension_language_mapping[extension]


### PR DESCRIPTION
<!--
Thanks for contributing to Voilà!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/voila-dashboards/voila/blob/main/CONTRIBUTING.md
-->

## References
Resolves #1422
<!-- Note issue numbers this pull request addresses. -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Simple boolean toggle that is checked to execute `fix_notebook`, `True` by default

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
N/A
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!--
For visual changes, include before and after screenshots here.

You will also need to update the reference screenshots for the Galata visual regression tests,
you can do this automatically by commenting "Please update galata references" in the PR.
-->

## Backwards-incompatible changes
N/A
<!-- Describe any backwards-incompatible changes to Voilà public APIs. -->
