### PR TITLE
Disambiguate voilà frontend via html data attributes

### DIFF
--- a/share/jupyter/voila/templates/base/page.html
+++ b/share/jupyter/voila/templates/base/page.html
@@ -20,7 +20,7 @@
 
   </head>
 
-  <body data-base-url="{{ base_url }}voila/">
+  <body data-base-url="{{ base_url }}voila/" data-voila="voila">
 
     <noscript>
       <div id='noscript'>

--- a/share/jupyter/voila/templates/classic/index.html.j2
+++ b/share/jupyter/voila/templates/classic/index.html.j2
@@ -58,7 +58,7 @@
 {%- endblock html_head_js_mathjax -%}
 
 {% block body_header %}
-<body data-base-url="{{resources.base_url}}voila/">
+<body data-base-url="{{resources.base_url}}voila/" data-voila="voila">
   {{ spinner.html() }}
   {{ voila_setup_helper_functions() }}
   <div tabindex="-1" id="notebook" class="border-box-sizing">

--- a/share/jupyter/voila/templates/lab/index.html.j2
+++ b/share/jupyter/voila/templates/lab/index.html.j2
@@ -59,11 +59,11 @@
 {%- block body_header -%}
 <link rel="icon" href="data:;base64,=">
 {% if resources.theme == 'dark' or resources.theme == 'JupyterLab Dark' %}
-<body class="jp-Notebook theme-dark" data-base-url="{{resources.base_url}}voila/" data-jp-theme-light="false" data-jp-theme-name="JupyterLab Dark">
+<body class="jp-Notebook theme-dark" data-base-url="{{resources.base_url}}voila/" data-jp-theme-light="false" data-jp-theme-name="JupyterLab Dark" data-voila="voila">
 {% elif resources.theme == 'light' or resources.theme == 'JupyterLab Light' %}
-<body class="jp-Notebook theme-light" data-base-url="{{resources.base_url}}voila/" data-jp-theme-light="true" data-jp-theme-name="JupyterLab Light">
+<body class="jp-Notebook theme-light" data-base-url="{{resources.base_url}}voila/" data-jp-theme-light="true" data-jp-theme-name="JupyterLab Light" data-voila="voila">
 {% else %}
-<body class="jp-Notebook" data-base-url="{{resources.base_url}}voila/" data-jp-theme-name="{{resources.theme}}">
+<body class="jp-Notebook" data-base-url="{{resources.base_url}}voila/" data-jp-theme-name="{{resources.theme}}" data-voila="voila">
 {% endif %}
 {{ spinner.html() }}
 {{ voila_setup_helper_functions() }}

--- a/share/jupyter/voila/templates/reveal/index.html.j2
+++ b/share/jupyter/voila/templates/reveal/index.html.j2
@@ -64,9 +64,9 @@
 
 {% block body_header %}
 {% if resources.theme == 'dark' %}
-<body class="jp-Notebook" data-base-url="{{resources.base_url}}voila/" data-jp-theme-light="false" data-jp-theme-name="JupyterLab Dark">
+<body class="jp-Notebook" data-base-url="{{resources.base_url}}voila/" data-jp-theme-light="false" data-jp-theme-name="JupyterLab Dark" data-voila="voila">
 {% else %}
-<body class="jp-Notebook" data-base-url="{{resources.base_url}}voila/" data-jp-theme-light="true" data-jp-theme-name="JupyterLab Light">
+<body class="jp-Notebook" data-base-url="{{resources.base_url}}voila/" data-jp-theme-light="true" data-jp-theme-name="JupyterLab Light" data-voila="voila">
 {% endif %}
 {{ spinner.html() }}
 {{ voila_setup_helper_functions() }}


### PR DESCRIPTION
## References
https://github.com/finos/perspective/pull/2588
https://github.com/finos/perspective/pull/2352
https://github.com/finos/perspective/issues/1773

## Code changes
This PR fixes Perspective, and maybe some other plugins. But more importantly: "if one is going to distinguish behavior that is specific to Voila, it can't share classnames with Jupyter." One should be able to differentiate voilà-specific behavior, since there are **legimate**, often *subtle* UI/UX differences with Lab/Notebook.

## User-facing changes
This adds some very basic html data attributes to the top level html body, namely `data-in-voila`. I don't think it matters what this string actually is, merely that it is present and unique to voilà. This attribute will allow extensions to differentiate the voilà frontend in what is, imo, a minimally invasive way.

## Backwards-incompatible changes
None!