### PR TITLE
Get mybinder.org working again

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -2,12 +2,10 @@ name: voila
 channels:
   - conda-forge
 dependencies:
-  - jupyterlab=3.6
+  - jupyterlab=4
   - ipywidgets=8
   - ipyvolume
   - bqplot
   - scipy
   - ipympl
-  - xleaflet=0.16.0
-  - xeus-cling=0.13.0
-  - python=3.10
+  - python=3.11

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -3,7 +3,4 @@
 set -e
 
 jlpm && jlpm run build
-python -m pip install -e .
-jupyter labextension develop . --overwrite
-jupyter server extension enable voila.server_extension --sys-prefix
-jupyter serverextension enable voila.server_extension --sys-prefix
+python -m pip install .


### PR DESCRIPTION
## References

N/A

## Code changes

The mybinder configuration is currently broken, this modifies the environment and build script so it's working again. The JupyterLab `Render with Voila` also works:
https://mybinder.org/v2/gh/manics/voila/binder

## User-facing changes
The mybinder.org link previously failed to build, now it works

## Backwards-incompatible changes

None