### PR TITLE
Set JPY_SESSION_NAME to the notebook path (same as jupyer_server does)

### DIFF
--- a/voila/handler.py
+++ b/voila/handler.py
@@ -27,6 +27,7 @@ from ._version import __version__
 from .notebook_renderer import NotebookRenderer
 from .request_info_handler import RequestInfoSocketHandler
 from .utils import ENV_VARIABLE, create_include_assets_functions, get_page_config
+from jupyter_server.utils import ApiPath, to_os_path
 
 
 class BaseVoilaHandler(JupyterHandler):
@@ -91,8 +92,14 @@ class VoilaHandler(BaseVoilaHandler):
             return
 
         cwd = os.path.dirname(notebook_path)
+        notebook_os_path = to_os_path(
+            ApiPath(notebook_path), os.path.abspath(self.contents_manager.root_dir)
+        )
+
         # Adding request uri to kernel env
         request_info = {}
+        # Expose the absolute OS path to the notebook in the same way as jupyter_server does
+        request_info[ENV_VARIABLE.JPY_SESSION_NAME] = notebook_os_path
         request_info[ENV_VARIABLE.SCRIPT_NAME] = self.request.path
         request_info[ENV_VARIABLE.PATH_INFO] = (
             ""  # would be /foo/bar if voila.ipynb/foo/bar was supported

--- a/voila/utils.py
+++ b/voila/utils.py
@@ -63,6 +63,7 @@ class ENV_VARIABLE(StringEnum):
     QUERY_STRING = "QUERY_STRING"
     SERVER_SOFTWARE = "SERVER_SOFTWARE"
     SERVER_PROTOCOL = "SERVER_PROTOCOL"
+    JPY_SESSION_NAME = "JPY_SESSION_NAME"
 
 
 def get_server_root_dir(settings):


### PR DESCRIPTION
<!--
Thanks for contributing to Voilà!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/voila-dashboards/voila/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses. -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

- https://github.com/jupyterlab/jupyterlab/issues/16282

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Set `JPY_SESSION_NAME` to the notebook path, same as `jupyer_server` does. This ensures that notebooks that use this feature in Jupyter Lab continue to work when served by voila.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!--
For visual changes, include before and after screenshots here.

You will also need to update the reference screenshots for the Galata visual regression tests,
you can do this automatically by commenting "Please update galata references" in the PR.
-->

- None

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to Voilà public APIs. -->

- None