### PR TITLE
Fix server extension configuration handling

### DIFF
--- a/voila/server_extension.py
+++ b/voila/server_extension.py
@@ -87,9 +87,8 @@ def _load_jupyter_server_extension(server_app: ServerApp):
     web_app = server_app.web_app
     # common configuration options between the server extension and the application
 
-    voila_configuration = VoilaConfiguration(
-        parent=server_app, config=load_config_file()
-    )
+    voila_configuration = VoilaConfiguration(parent=server_app)
+    voila_configuration.config.merge(load_config_file())
 
     template_name = voila_configuration.template
     template_paths = collect_template_paths(["voila", "nbconvert"], template_name)


### PR DESCRIPTION
We were wrongfully overwriting the config since 0.5.7. This had the byproduct of the following not working correctly:
```
jupyter lab --VoilaConfiguration.theme='dark'
```