### PR TITLE
fix: add websocket ping responses to avoid timeouts from torando

### DIFF
--- a/packages/voila/src/plugins/outputs/plugins.ts
+++ b/packages/voila/src/plugins/outputs/plugins.ts
@@ -154,6 +154,10 @@ export const renderOutputsProgressivelyPlugin: JupyterFrontEndPlugin<void> = {
           console.error(`Execution error: ${payload.error}`);
           break;
         }
+        case 'ping': {
+          ws.send(JSON.stringify({ action: 'pong' }));
+          break;
+        }
         default:
           break;
       }

--- a/packages/voila/src/plugins/outputs/tools.ts
+++ b/packages/voila/src/plugins/outputs/tools.ts
@@ -28,6 +28,14 @@ export interface IExecutionErrorMessage {
 }
 
 /**
+ * Interface representing the structure of an execution's ping and pong message.
+ */
+export interface IExecutionResultPingMessage {
+  action: 'ping';
+  payload: any;
+}
+
+/**
  * Interface representing a received widget model
  * containing output and execution models.
  */
@@ -39,7 +47,8 @@ export interface IReceivedWidgetModel {
 }
 export type IExecutionMessage =
   | IExecutionResultMessage
-  | IExecutionErrorMessage;
+  | IExecutionErrorMessage
+  | IExecutionResultPingMessage;
 
 export function getExecutionURL(kernelId?: string): string {
   const wsUrl = PageConfig.getWsUrl();


### PR DESCRIPTION
<!--
Thanks for contributing to Voilà!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/voila-dashboards/voila/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses. -->

When rendering reports on progressive mode, any long running notebook will hang indefinitely.

This can be easily recreated with a notebook:
```
import time
time.sleep(91)
print('hi')
```
The tornado websockets issue ping actions and expect pong requests back or they will kill the websocket, resulting in any notebook requiring more than 90 seconds to run to hang indefinitely.

## Code changes

Added a pong response to pings so the tornado websockets aren't killed.

## User-facing changes

Slow notebooks will render in progressive rendering mode.


## Backwards-incompatible changes

This fix is fully backwards compatible.
