### PR TITLE
Allow specifying extra_labextensions_path

### DIFF
--- a/voila/app.py
+++ b/voila/app.py
@@ -474,7 +474,9 @@ class Voila(Application):
 
     @property
     def labextensions_path(self):
-        return get_voila_labextensions_path()
+        return get_voila_labextensions_path(
+            self.voila_configuration.extra_labextensions_path
+        )
 
     @property
     def data_dir(self):
@@ -761,7 +763,9 @@ class Voila(Application):
                     {
                         "themes_url": "/voila/api/themes",
                         "path": self.themes_dir,
-                        "labextensions_path": get_voila_labextensions_path(),
+                        "labextensions_path": get_voila_labextensions_path(
+                            self.voila_configuration.extra_labextensions_path
+                        ),
                         "no_cache_paths": ["/"],
                     },
                 ),

--- a/voila/configuration.py
+++ b/voila/configuration.py
@@ -269,3 +269,9 @@ class VoilaConfiguration(traitlets.config.Configurable):
         This option is not compatible with preheat-kernel option.
         """,
     )
+
+    extra_labextensions_path = List(
+        Unicode(),
+        config=True,
+        help="""Extra paths to look for federated JupyterLab extensions""",
+    )

--- a/voila/server_extension.py
+++ b/voila/server_extension.py
@@ -125,7 +125,9 @@ def _load_jupyter_server_extension(server_app: ServerApp):
     tree_handler_conf = {"voila_configuration": voila_configuration}
 
     themes_dir = pjoin(get_data_dir(), "themes")
-    labextensions_path = get_voila_labextensions_path()
+    labextensions_path = get_voila_labextensions_path(
+        voila_configuration.extra_labextensions_path
+    )
 
     handlers = [
         (

--- a/voila/utils.py
+++ b/voila/utils.py
@@ -92,7 +92,7 @@ async def _get_request_info(ws_url: str) -> Awaitable:
         return ri
 
 
-def get_voila_labextensions_path():
+def get_voila_labextensions_path(extra_paths=None):
     labextensions_path = jupyter_path("labextensions")
 
     # Paths to labextensions specific to Voila
@@ -100,6 +100,10 @@ def get_voila_labextensions_path():
         str(Path(path) / "labextensions") for path in jupyter_path("voila")
     ]
     labextensions_path = labextensions_path + voila_labextensions
+
+    # Add extra labextensions paths if provided
+    if extra_paths:
+        labextensions_path = labextensions_path + extra_paths
 
     return labextensions_path
 
@@ -136,7 +140,9 @@ def get_page_config(
     )
     page_config.setdefault("mathjaxConfig", mathjax_config)
     page_config.setdefault("fullMathjaxUrl", mathjax_url)
-    labextensions_path = get_voila_labextensions_path()
+    labextensions_path = get_voila_labextensions_path(
+        voila_configuration.extra_labextensions_path
+    )
 
     recursive_update(
         page_config,


### PR DESCRIPTION
<!--
Thanks for contributing to Voilà!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/voila-dashboards/voila/blob/main/CONTRIBUTING.md
-->

## References

Similar to JupyterLab / JupyterLab Server: https://github.com/jupyterlab/jupyterlab_server/blob/bca8978ffd44093bc4e7c790d8ee064d2f2b492a/jupyterlab_server/config.py#L233-L235


## Code changes

Add a new `extra_labextensions_path` trait to `VoilaConfiguration`.

## User-facing changes

None for end users.

More flexibility for administrators.


## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to Voilà public APIs. -->
