### PR TITLE
Add JupyterLab 4 classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Framework :: Jupyter",
     "Framework :: Jupyter :: JupyterLab",
     "Framework :: Jupyter :: JupyterLab :: 3",
+    "Framework :: Jupyter :: JupyterLab :: 4",
     "Framework :: Jupyter :: JupyterLab :: Extensions",
     "Framework :: Jupyter :: JupyterLab :: Extensions :: Prebuilt",
     "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
## Summary
- add the `Framework :: Jupyter :: JupyterLab :: 4` trove classifier so PyPI metadata matches the supported Lab major version
- support for Lab 4 is already established through the prebuilt frontend, e.g. the labextension depends on `@jupyterlab/application@^4.0.0` in [packages/voila/package.json](https://github.com/voila-dashboards/voila/blob/main/packages/voila/package.json)

## Testing
- not run