### PR TITLE
Update "Render with Voila" menu and tooltip text to include "applications"

### DIFF
--- a/packages/jupyterlab-preview/src/index.ts
+++ b/packages/jupyterlab-preview/src/index.ts
@@ -67,7 +67,7 @@ class VoilaRenderButton
   createNew(panel: NotebookPanel): IDisposable {
     const button = new ToolbarButton({
       className: 'voilaRender',
-      tooltip: 'Render with Voilà',
+      tooltip: 'Render Notebook as Web Application with Voilà',
       icon: voilaIcon,
       onClick: () => {
         this._commands.execute(CommandIDs.voilaRender);
@@ -177,7 +177,7 @@ const extension: JupyterFrontEndPlugin<IVoilaPreviewTracker> = {
     const { commands, docRegistry } = app;
 
     commands.addCommand(CommandIDs.voilaRender, {
-      label: 'Render Notebook with Voilà',
+      label: 'Preview Notebook as Web Application with Voilà',
       execute: async (args) => {
         const current = getCurrent(args);
         let context: DocumentRegistry.IContext<INotebookModel>;

--- a/packages/jupyterlab-preview/src/index.ts
+++ b/packages/jupyterlab-preview/src/index.ts
@@ -69,7 +69,7 @@ class VoilaRenderButton
   createNew(panel: NotebookPanel): IDisposable {
     const button = new ToolbarButton({
       className: 'voilaRender',
-      tooltip: 'Render with Voilà',
+      tooltip: 'Render Notebook as Web Application with Voilà',
       icon: voilaIcon,
       onClick: () => {
         this._commands.execute(CommandIDs.voilaRender);
@@ -179,7 +179,7 @@ const extension: JupyterFrontEndPlugin<IVoilaPreviewTracker> = {
     const { commands, docRegistry } = app;
 
     commands.addCommand(CommandIDs.voilaRender, {
-      label: 'Render Notebook with Voilà',
+      label: 'Preview Notebook as Web Application with Voilà',
       execute: async (args) => {
         const current = getCurrent(args);
         let context: DocumentRegistry.IContext<INotebookModel>;


### PR DESCRIPTION
<!--
Thanks for contributing to Voilà!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/voila-dashboards/voila/blob/main/CONTRIBUTING.md
-->

The menu items and buttons for Voila preview do not mention previewing as web applications. Users of Voila who have not added the package themselves may not know that Voila can be used to preview notebooks as applications. Renaming the menu items and buttons to explicitly mention applications might make it clearer for users. 

## References

<!-- Note issue numbers this pull request addresses. -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Updated the voila preview menu item label and the tooltip to include "application"
## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
The user-facing text of the voila preview menu item has been updated. The tooltip of the voila preview button has also been updated 
Menu item before change:
<img width="406" height="116" alt="image" src="https://github.com/user-attachments/assets/8d0ac316-4593-41b6-b48b-7e9fca1d0acd" />
Menu item after change:
<img width="619" height="173" alt="image (2)" src="https://github.com/user-attachments/assets/b512be20-3d11-412b-9d78-0e5e3a0be960" />

Tooltip before change:
<img width="406" height="116" alt="image (3)" src="https://github.com/user-attachments/assets/db3fffc9-3b35-46f5-9928-8e4c210d3af6" />
Tooltip after change:
<img width="406" height="116" alt="image (1)" src="https://github.com/user-attachments/assets/dc9b8b1c-f8e9-468d-a2c7-f3495325165a" />
<!--
For visual changes, include before and after screenshots here.



You will also need to update the reference screenshots for the Galata visual regression tests,
you can do this automatically by commenting "Please update galata references" in the PR.
-->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to Voilà public APIs. -->
