### PR TITLE
[Enhancement] - Normalize extra labextensions path | #1553

### DIFF
--- a/docs/customize.md
+++ b/docs/customize.md
@@ -795,3 +795,7 @@ c.VoilaConfiguration.extra_labextensions_path = [
     '/another/path'
 ]
 ```
+
+:::{note}
+The `extra_labextensions_path` directories are prepended to the default `labextensions_path`. In other words, extensions in the `extra_labextensions_path` will take precedence over those in the standard locations.
+:::

--- a/voila/utils.py
+++ b/voila/utils.py
@@ -103,7 +103,7 @@ def get_voila_labextensions_path(extra_paths=None):
 
     # Add extra labextensions paths if provided
     if extra_paths:
-        labextensions_path = labextensions_path + extra_paths
+        labextensions_path = extra_paths + labextensions_path
 
     return labextensions_path
 


### PR DESCRIPTION
## Description

Ensuring feature parity with [jupyterlab_server](https://github.com/jupyterlab/jupyterlab_server)  by  making `labextensions_path`  behavior consistent across both the repositories. 

## Technical Description

Within `jupyterlab_server` repository - the `extra_labextensions_path` is prepended to `labextensions_path`,  [reference](https://github.com/jupyterlab/jupyterlab_server/blob/f64f554291a09f072e479ff52ae2212084aaac39/jupyterlab_server/handlers.py#L219).  

However, the code from `voila` repository is not consistent with this behavior. Within `voila` the `extra_labextensions_path` is [being appended](https://github.com/jtpio/voila/blob/ae0d1a906d3fdd1583d96714155b410f7a8c8641/voila/utils.py#L106) which changes the order in which the extensions are loaded.  

This PR aims to make this behavior consistent

## Code changes

This code modifies the order in which the `labextensions_path` is constructed when the `extra_labextensions_path` is non-empty.  Currently, the `extra_labextensions_path` was being appended to the path but this PR aims to prepend it instead.  

## User-facing changes

Extensions in the `extra_labextensions_path` will take precedence over those in the standard locations - `labextensions_path`

## Backwards-incompatible changes

Lab extensions path lookup order will change

## References

1. [Issue link](https://github.com/voila-dashboards/voila/issues/1553)
2. Related [PR](https://github.com/voila-dashboards/voila/pull/1542)

