### PR TITLE
Export `IVoilaPreviewTracker`

### DIFF
--- a/packages/jupyterlab-preview/src/index.ts
+++ b/packages/jupyterlab-preview/src/index.ts
@@ -38,6 +38,8 @@ import {
 
 import { voilaIcon } from './icons';
 
+export { VoilaPreview, IVoilaPreviewTracker, VoilaPreviewFactory };
+
 /**
  * The command IDs used by the plugin.
  */


### PR DESCRIPTION

## References

This will help other extensions consume that tracker and for example add more buttons to the voila preview toolbar.

## Code changes

- [x] Export `IVoilaPreviewTracker` from `@voila-dashboards/jupyterlab-preview` 

## User-facing changes

None

## Backwards-incompatible changes

None
