### PR TITLE
Point to GH gallery page

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Voilà is built upon Jupyter standard formats and protocols, and is agnostic to 
 
 ## The Voilà Gallery
 
-The [Voilà Gallery](https://voila-gallery.org) is a collection of live dashboards and applications built with Voilà and Jupyter widgets.
+The [Voilà Gallery](https://voila-gallery.github.io/) is a collection of live dashboards and applications built with Voilà and Jupyter widgets.
 
 Most of the examples rely on widget libraries such as ipywidgets, ipyleaflet, ipyvolume, bqplot and ipympl, and showcase how to build complex web applications entirely based on notebooks.
 


### PR DESCRIPTION
Fix voila dashboard webpage URL; point to the GH pages gallery page instead of https://voila-gallery.org/ (which doesn't load).

## References

<!-- Note issue numbers this pull request addresses. -->
https://github.com/voila-gallery/voila-gallery.github.io/issues/48
https://github.com/voila-dashboards/tljh-voila-gallery/issues/97

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

https://github.com/voila-gallery/voila-gallery.github.io/pull/49

## Code changes

URL change.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!--
For visual changes, include before and after screenshots here.

You will also need to update the reference screenshots for the Galata visual regression tests,
you can do this automatically by commenting "Please update galata references" in the PR.
-->
NA

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to Voilà public APIs. -->
NA
