### PR TITLE
request confirmation before rendering untrusted notebook

### DIFF
--- a/packages/jupyterlab-preview/src/index.ts
+++ b/packages/jupyterlab-preview/src/index.ts
@@ -213,6 +213,16 @@ const extension: JupyterFrontEndPlugin<IVoilaPreviewTracker> = {
         if (!current) {
           return;
         }
+        // Voila executes the notebook, so ask for confirmation first if it is
+        // not trusted.
+        try {
+          if (!(await VoilaPreview.ensureTrusted(current.context))) {
+            return;
+          }
+        } catch (e) {
+          console.error(e);
+          return;
+        }
         try {
           await current.context.save();
         } catch (e) {

--- a/packages/jupyterlab-preview/src/index.ts
+++ b/packages/jupyterlab-preview/src/index.ts
@@ -185,10 +185,14 @@ const extension: JupyterFrontEndPlugin<IVoilaPreviewTracker> = {
         let context: DocumentRegistry.IContext<INotebookModel>;
         if (current) {
           context = current.context;
-          try {
-            await context.save();
-          } catch (e) {
-            console.error(e);
+          // Check if notebook is trusted before saving it
+          const trusted = VoilaPreview.checkTrustStatus(current.model?.cells);
+          if (trusted) {
+            try {
+              await context.save();
+            } catch (e) {
+              console.error(e);
+            }
           }
           commands.execute('docmanager:open', {
             path: context.path,

--- a/packages/jupyterlab-preview/src/preview.tsx
+++ b/packages/jupyterlab-preview/src/preview.tsx
@@ -6,7 +6,6 @@ import {
   showDialog,
   Dialog
 } from '@jupyterlab/apputils';
-
 import {
   ABCWidgetFactory,
   DocumentRegistry,
@@ -50,7 +49,6 @@ export class VoilaPreview extends DocumentWidget<IFrame, INotebookModel> {
       ...options,
       content: new IFrame()
     });
-
     const iframe = this.content.node.querySelector('iframe');
     if (iframe) {
       iframe.removeAttribute('sandbox');
@@ -86,37 +84,16 @@ export class VoilaPreview extends DocumentWidget<IFrame, INotebookModel> {
       }
     };
 
+    this.content.title.icon = voilaIcon;
     const { getVoilaUrl, context, renderOnSave } = options;
 
-    const trusted = VoilaPreview.checkTrustStatus(context.model.cells);
-    if (trusted) {
-      this.content.url = getVoilaUrl(context.path);
-    } else {
-      const accept = showDialog({
-        title: 'Untrusted notebook detected',
-        hasClose: false,
-        body: 'The notebook is not trusted, do you want to render it?\nYou can trust this notebook by running the "Trust Notebook" command from the command palette.',
-        buttons: [Dialog.cancelButton(), Dialog.okButton()]
-      });
-      accept
-        .then((result) => {
-          if (result.button.accept) {
-            this.content.url = getVoilaUrl(context.path);
-          } else {
-            this.dispose();
-          }
-        })
-        .catch(() => {
-          this.dispose();
-        });
-    }
-    this.content.title.icon = voilaIcon;
-
     this._renderOnSave = renderOnSave ?? false;
-
-    context.pathChanged.connect(() => {
-      this.content.url = getVoilaUrl(context.path);
-    });
+    this._getVoilaUrl = getVoilaUrl;
+    try {
+      this._init(context);
+    } catch (e) {
+      return;
+    }
 
     const reloadButton = new ToolbarButton({
       icon: refreshIcon,
@@ -147,16 +124,7 @@ export class VoilaPreview extends DocumentWidget<IFrame, INotebookModel> {
 
     this.toolbar.addItem('reload', reloadButton);
 
-    if (context) {
-      this.toolbar.addItem('renderOnSave', renderOnSaveCheckbox);
-      void context.ready.then(() => {
-        context.fileChanged.connect(() => {
-          if (this.renderOnSave) {
-            this.reload();
-          }
-        });
-      });
-    }
+    this.toolbar.addItem('renderOnSave', renderOnSaveCheckbox);
   }
 
   /**
@@ -194,7 +162,81 @@ export class VoilaPreview extends DocumentWidget<IFrame, INotebookModel> {
     this._renderOnSave = renderOnSave;
   }
 
+  private async _init(
+    context: DocumentRegistry.IContext<INotebookModel>
+  ): Promise<void> {
+    await context.ready;
+    const trusted = VoilaPreview.checkTrustStatus(context.model.cells);
+    if (trusted) {
+      this.content.url = this._getVoilaUrl(context.path);
+    } else {
+      const body = (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            maxWidth: '600px'
+          }}
+        >
+          <span>
+            It seems that you are rendering a notebook that you have received
+            from a third party.
+          </span>
+          <span>
+            Executing an untrusted Jupyter notebook may execute malicious code.
+            If you trust the content of this document, you can select{' '}
+            <b>Render anyway</b>, which will mark this notebook as trusted and
+            run it.
+          </span>
+          <span>
+            For more information, see{' '}
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://jupyter-server.readthedocs.io/en/stable/operators/security.html#security-in-notebook-documents"
+            >
+              the Jupyter security documentation
+            </a>
+            .
+          </span>
+        </div>
+      );
+      try {
+        const result = await showDialog({
+          title: 'Untrusted notebook detected',
+          hasClose: false,
+          body,
+          buttons: [
+            Dialog.cancelButton(),
+            Dialog.okButton({ label: 'Render anyway' })
+          ]
+        });
+        if (result.button.accept) {
+          await VoilaPreview.trustNotebook({ context });
+          this.content.url = this._getVoilaUrl(context.path);
+          context.fileChanged.connect(() => {
+            if (this.renderOnSave) {
+              this.reload();
+            }
+          });
+
+          context.pathChanged.connect(() => {
+            this.content.url = this._getVoilaUrl(context.path);
+          });
+        } else {
+          this.dispose();
+          return;
+        }
+      } catch (e) {
+        console.error('Error while checking notebook trust', e);
+        this.dispose();
+        return;
+      }
+    }
+  }
+
   private _renderOnSave: boolean;
+  private _getVoilaUrl: (path: string) => string;
 }
 
 /**
@@ -217,7 +259,20 @@ export namespace VoilaPreview {
     renderOnSave?: boolean;
   }
 
-  export function checkTrustStatus(cells: CellList): boolean {
+  export async function trustNotebook({
+    context
+  }: {
+    context: DocumentRegistry.IContext<INotebookModel>;
+  }) {
+    for (const cell of context.model.cells) {
+      cell.trusted = true;
+    }
+    await context.save();
+  }
+  export function checkTrustStatus(cells?: CellList): boolean {
+    if (!cells) {
+      return true;
+    }
     for (let i = 0; i < cells.length; i++) {
       const cell = cells.get(i);
       if (cell.type === 'code' && cell.getMetadata('trusted') === false) {

--- a/packages/jupyterlab-preview/src/preview.tsx
+++ b/packages/jupyterlab-preview/src/preview.tsx
@@ -89,11 +89,10 @@ export class VoilaPreview extends DocumentWidget<IFrame, INotebookModel> {
 
     this._renderOnSave = renderOnSave ?? false;
     this._getVoilaUrl = getVoilaUrl;
-    try {
-      this._init(context);
-    } catch (e) {
-      return;
-    }
+    void this._init(context).catch((e) => {
+      console.error('Failed to initialize the Voila preview', e);
+      this.dispose();
+    });
 
     const reloadButton = new ToolbarButton({
       icon: refreshIcon,
@@ -162,77 +161,32 @@ export class VoilaPreview extends DocumentWidget<IFrame, INotebookModel> {
     this._renderOnSave = renderOnSave;
   }
 
+  /**
+   * Initialize the preview once the context is ready.
+   *
+   * @param context The document context.
+   */
   private async _init(
     context: DocumentRegistry.IContext<INotebookModel>
   ): Promise<void> {
     await context.ready;
-    const trusted = VoilaPreview.checkTrustStatus(context.model.cells);
-    if (trusted) {
-      this.content.url = this._getVoilaUrl(context.path);
-    } else {
-      const body = (
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            maxWidth: '600px'
-          }}
-        >
-          <span>
-            It seems that you are rendering a notebook that you have received
-            from a third party.
-          </span>
-          <span>
-            Executing an untrusted Jupyter notebook may execute malicious code.
-            If you trust the content of this document, you can select{' '}
-            <b>Render anyway</b>, which will mark this notebook as trusted and
-            run it.
-          </span>
-          <span>
-            For more information, see{' '}
-            <a
-              target="_blank"
-              rel="noopener noreferrer"
-              href="https://jupyter-server.readthedocs.io/en/stable/operators/security.html#security-in-notebook-documents"
-            >
-              the Jupyter security documentation
-            </a>
-            .
-          </span>
-        </div>
-      );
-      try {
-        const result = await showDialog({
-          title: 'Untrusted notebook detected',
-          hasClose: false,
-          body,
-          buttons: [
-            Dialog.cancelButton(),
-            Dialog.okButton({ label: 'Render anyway' })
-          ]
-        });
-        if (result.button.accept) {
-          await VoilaPreview.trustNotebook({ context });
-          this.content.url = this._getVoilaUrl(context.path);
-          context.fileChanged.connect(() => {
-            if (this.renderOnSave) {
-              this.reload();
-            }
-          });
 
-          context.pathChanged.connect(() => {
-            this.content.url = this._getVoilaUrl(context.path);
-          });
-        } else {
-          this.dispose();
-          return;
-        }
-      } catch (e) {
-        console.error('Error while checking notebook trust', e);
-        this.dispose();
-        return;
-      }
+    if (!(await VoilaPreview.ensureTrusted(context))) {
+      this.dispose();
+      return;
     }
+
+    context.fileChanged.connect(() => {
+      if (this.renderOnSave) {
+        this.reload();
+      }
+    });
+
+    context.pathChanged.connect(() => {
+      this.content.url = this._getVoilaUrl(context.path);
+    });
+
+    this.content.url = this._getVoilaUrl(context.path);
   }
 
   private _renderOnSave: boolean;
@@ -259,26 +213,103 @@ export namespace VoilaPreview {
     renderOnSave?: boolean;
   }
 
+  /**
+   * Mark every cell of a notebook as trusted and save it.
+   *
+   * @param context The document context.
+   */
   export async function trustNotebook({
     context
   }: {
     context: DocumentRegistry.IContext<INotebookModel>;
-  }) {
+  }): Promise<void> {
     for (const cell of context.model.cells) {
       cell.trusted = true;
     }
     await context.save();
   }
+
+  /**
+   * Whether every code cell of a notebook is trusted.
+   *
+   * A missing trust status is treated as untrusted, to match the behavior of
+   * `CellModel`.
+   *
+   * @param cells The cells of the notebook.
+   */
   export function checkTrustStatus(cells?: CellList): boolean {
     if (!cells) {
-      return true;
+      return false;
     }
-    for (let i = 0; i < cells.length; i++) {
-      const cell = cells.get(i);
-      if (cell.type === 'code' && cell.getMetadata('trusted') === false) {
+    for (const cell of cells) {
+      if (cell.type === 'code' && !cell.trusted) {
         return false;
       }
     }
+    return true;
+  }
+
+  /**
+   * Make sure a notebook is trusted before Voila executes it, asking the user
+   * for confirmation if it is not.
+   *
+   * @param context The document context.
+   * @returns Whether the notebook may be rendered.
+   */
+  export async function ensureTrusted(
+    context: DocumentRegistry.IContext<INotebookModel>
+  ): Promise<boolean> {
+    if (checkTrustStatus(context.model?.cells)) {
+      return true;
+    }
+
+    const body = (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          maxWidth: '600px'
+        }}
+      >
+        <span>
+          It seems that you are rendering a notebook that you have received from
+          a third party.
+        </span>
+        <span>
+          Executing an untrusted Jupyter notebook may execute malicious code. If
+          you trust the content of this document, you can select{' '}
+          <b>Render anyway</b>, which will mark this notebook as trusted and run
+          it.
+        </span>
+        <span>
+          For more information, see{' '}
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://jupyter-server.readthedocs.io/en/stable/operators/security.html#security-in-notebook-documents"
+          >
+            the Jupyter security documentation
+          </a>
+          .
+        </span>
+      </div>
+    );
+
+    const result = await showDialog({
+      title: 'Untrusted notebook detected',
+      hasClose: false,
+      body,
+      buttons: [
+        Dialog.cancelButton(),
+        Dialog.okButton({ label: 'Render anyway' })
+      ]
+    });
+
+    if (!result.button.accept) {
+      return false;
+    }
+
+    await trustNotebook({ context });
     return true;
   }
 }

--- a/packages/jupyterlab-preview/src/preview.tsx
+++ b/packages/jupyterlab-preview/src/preview.tsx
@@ -2,7 +2,9 @@ import {
   IFrame,
   ToolbarButton,
   ReactWidget,
-  IWidgetTracker
+  IWidgetTracker,
+  showDialog,
+  Dialog
 } from '@jupyterlab/apputils';
 
 import {
@@ -11,7 +13,7 @@ import {
   DocumentWidget
 } from '@jupyterlab/docregistry';
 
-import { INotebookModel } from '@jupyterlab/notebook';
+import { CellList, INotebookModel } from '@jupyterlab/notebook';
 
 import { refreshIcon } from '@jupyterlab/ui-components';
 
@@ -86,7 +88,28 @@ export class VoilaPreview extends DocumentWidget<IFrame, INotebookModel> {
 
     const { getVoilaUrl, context, renderOnSave } = options;
 
-    this.content.url = getVoilaUrl(context.path);
+    const trusted = VoilaPreview.checkTrustStatus(context.model.cells);
+    if (trusted) {
+      this.content.url = getVoilaUrl(context.path);
+    } else {
+      const accept = showDialog({
+        title: 'Untrusted notebook detected',
+        hasClose: false,
+        body: 'The notebook is not trusted, do you want to render it?\nYou can trust this notebook by running the "Trust Notebook" command from the command palette.',
+        buttons: [Dialog.cancelButton(), Dialog.okButton()]
+      });
+      accept
+        .then((result) => {
+          if (result.button.accept) {
+            this.content.url = getVoilaUrl(context.path);
+          } else {
+            this.dispose();
+          }
+        })
+        .catch(() => {
+          this.dispose();
+        });
+    }
     this.content.title.icon = voilaIcon;
 
     this._renderOnSave = renderOnSave ?? false;
@@ -192,6 +215,16 @@ export namespace VoilaPreview {
      * Whether to reload the preview on context saved.
      */
     renderOnSave?: boolean;
+  }
+
+  export function checkTrustStatus(cells: CellList): boolean {
+    for (let i = 0; i < cells.length; i++) {
+      const cell = cells.get(i);
+      if (cell.type === 'code' && cell.getMetadata('trusted') === false) {
+        return false;
+      }
+    }
+    return true;
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Voilà!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/voila-dashboards/voila/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses. -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

When opening a notebook using the Voila preview, users need to confirm that they want to render untrusted one


https://github.com/user-attachments/assets/79544d5e-477d-47f4-a77e-196ec7caf2f5



<!--
For visual changes, include before and after screenshots here.

You will also need to update the reference screenshots for the Galata visual regression tests,
you can do this automatically by commenting "Please update galata references" in the PR.
-->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to Voilà public APIs. -->
