### PR TITLE
Patching the reveal template to fix ipywidgets 8 support there + fix CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ share/jupyter/voila/templates/base/static/*.ttf
 share/jupyter/voila/templates/base/static/labvariables.css
 share/jupyter/voila/templates/base/static/materialcolors.css
 share/jupyter/voila/templates/base/static/*.LICENSE.txt
+share/jupyter/voila/templates/base/static/reveal.js
 
 
 lib

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,10 +40,10 @@ repos:
       - id: prettier
         name: prettier
         entry: 'yarn run prettier'
-        language: node
+        language: system
         types_or: [json, ts, tsx, javascript, jsx, css]
       - id: eslint
         name: eslint
         entry: 'yarn run eslint'
-        language: node
+        language: system
         types_or: [ts, tsx, javascript, jsx]

--- a/.yarn/patches/reveal.js-npm-6.0.1-1c7308d1ac.patch
+++ b/.yarn/patches/reveal.js-npm-6.0.1-1c7308d1ac.patch
@@ -1,0 +1,15 @@
+diff --git a/package.json b/package.json
+index b70e852a1612e9f58b7ba0f8e409f9c1b551208c..b3426e77435de26241e550c3c63c0b7e536b4a8c 100644
+--- a/package.json
++++ b/package.json
+@@ -64,6 +64,10 @@
+ 			"import": "./dist/plugin/zoom.mjs",
+ 			"require": "./dist/plugin/zoom.js",
+ 			"default": "./dist/plugin/zoom.js"
++		},
++		"./package.json": {
++			"import": "./package.json",
++			"require": "./package.json"
+ 		}
+ 	},
+ 	"scripts": {

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - myst-parser
   - nodejs
-  - jupyterlab
+  - jupyterlab=4.5
   - sphinx
   - pydata-sphinx-theme
   - pip:

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
-  "npmClient": "yarn",
+  "npmClient": "jlpm",
   "version": "independent"
 }

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
     "prettier": "^2.8.6",
     "rimraf": "^3.0.2",
     "shell-quote": "^1.7.2"
+  },
+  "resolutions": {
+    "reveal.js@^6.0.1": "patch:reveal.js@npm%3A6.0.1#./.yarn/patches/reveal.js-npm-6.0.1-1c7308d1ac.patch"
   }
 }

--- a/packages/voila/package.json
+++ b/packages/voila/package.json
@@ -55,6 +55,7 @@
     "@voila-dashboards/widgets-manager8": "^0.5.12",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "reveal.js": "^6.0.1",
     "style-mod": "^4.0.3",
     "util": "^0.12.5"
   },

--- a/packages/voila/src/revealbootstrap.ts
+++ b/packages/voila/src/revealbootstrap.ts
@@ -1,6 +1,6 @@
 // This is more or less copied from the nbconvert reveal template
 import Reveal from 'reveal.js';
-// @ts-expect-error
+// @ts-expect-error should probably look it up
 import Notes from 'reveal.js/plugin/notes';
 
 // @ts-expect-error It's provided by the template
@@ -21,37 +21,38 @@ const $ = window.$;
 
 // Full list of configuration options available here: https://github.com/hakimel/reveal.js#configuration
 Reveal.initialize({
-    controls: true,
-    progress: true,
-    history: true,
-    transition: reveal_transition,
-    slideNumber: reveal_number,
-    plugins: [Notes],
-    width: reveal_width,
-    height: reveal_height,
+  controls: true,
+  progress: true,
+  history: true,
+  transition: reveal_transition,
+  slideNumber: reveal_number,
+  plugins: [Notes],
+  width: reveal_width,
+  height: reveal_height
 });
 
-var update = function(){
-    if(MathJax.Hub.getAllJax(Reveal.getCurrentSlide())){
-        MathJax.Hub.Rerender(Reveal.getCurrentSlide());
-    }
+const update = function () {
+  if (MathJax.Hub.getAllJax(Reveal.getCurrentSlide())) {
+    MathJax.Hub.Rerender(Reveal.getCurrentSlide());
+  }
 };
 
 Reveal.addEventListener('slidechanged', update);
 
 function setScrollingSlide() {
-    var scroll = reveal_scroll;
-    if (scroll === true) {
-        var h = ($('.reveal').height() ?? 0) * 0.95;
-        $('section.present').find('section')
-        .filter(function() {
-            // @ts-expect-error hey
-            return $(this).height() > h;
-        })
-        .css('height', 'calc(95vh)')
-        .css('overflow-y', 'scroll')
-        .css('margin-top', '20px');
-    }
+  const scroll = reveal_scroll;
+  if (scroll === true) {
+    const h = ($('.reveal').height() ?? 0) * 0.95;
+    $('section.present')
+      .find('section')
+      .filter(function () {
+        // @ts-expect-error hey
+        return $(this).height() > h;
+      })
+      .css('height', 'calc(95vh)')
+      .css('overflow-y', 'scroll')
+      .css('margin-top', '20px');
+  }
 }
 
 // check and set the scrolling slide every time the slide change

--- a/packages/voila/src/revealbootstrap.ts
+++ b/packages/voila/src/revealbootstrap.ts
@@ -1,0 +1,58 @@
+// This is more or less copied from the nbconvert reveal template
+import Reveal from 'reveal.js';
+// @ts-expect-error
+import Notes from 'reveal.js/plugin/notes';
+
+// @ts-expect-error It's provided by the template
+const MathJax = window.MathJax;
+
+// @ts-expect-error It's provided by the template
+const reveal_transition = window.reveal_transition;
+// @ts-expect-error It's provided by the template
+const reveal_number = window.reveal_number;
+// @ts-expect-error It's provided by the template
+const reveal_width = window.reveal_width;
+// @ts-expect-error It's provided by the template
+const reveal_height = window.reveal_height;
+// @ts-expect-error It's provided by the template
+const reveal_scroll = window.reveal_scroll;
+// @ts-expect-error It's provided by the template
+const $ = window.$;
+
+// Full list of configuration options available here: https://github.com/hakimel/reveal.js#configuration
+Reveal.initialize({
+    controls: true,
+    progress: true,
+    history: true,
+    transition: reveal_transition,
+    slideNumber: reveal_number,
+    plugins: [Notes],
+    width: reveal_width,
+    height: reveal_height,
+});
+
+var update = function(){
+    if(MathJax.Hub.getAllJax(Reveal.getCurrentSlide())){
+        MathJax.Hub.Rerender(Reveal.getCurrentSlide());
+    }
+};
+
+Reveal.addEventListener('slidechanged', update);
+
+function setScrollingSlide() {
+    var scroll = reveal_scroll;
+    if (scroll === true) {
+        var h = ($('.reveal').height() ?? 0) * 0.95;
+        $('section.present').find('section')
+        .filter(function() {
+            // @ts-expect-error hey
+            return $(this).height() > h;
+        })
+        .css('height', 'calc(95vh)')
+        .css('overflow-y', 'scroll')
+        .css('margin-top', '20px');
+    }
+}
+
+// check and set the scrolling slide every time the slide change
+Reveal.addEventListener('slidechanged', setScrollingSlide);

--- a/packages/voila/webpack.config.js
+++ b/packages/voila/webpack.config.js
@@ -48,6 +48,7 @@ const extras = Build.ensureAssets({
 // Make a bootstrap entrypoint
 const entryPoint = path.join(buildDir, 'bootstrap.js');
 const treeEntryPoint = path.join(buildDir, 'treebootstrap.js');
+const revealEntryPoint = path.join(buildDir, 'revealbootstrap.js');
 
 // Also build the style bundle
 const styleDir = path.resolve(__dirname, 'style');
@@ -112,6 +113,14 @@ module.exports = [
     output: {
       path: distRoot,
       filename: 'voila-style.js'
+    }
+  }),
+  merge(baseConfig, {
+    entry: './' + path.relative(__dirname, revealEntryPoint),
+    mode: 'production',
+    output: {
+      path: distRoot,
+      filename: 'reveal.js'
     }
   })
 ].concat(extras);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=1.8.1",
-    "jupyterlab~=4.0",
+    "jupyterlab==4.5.10",
     "jupyter_core",
 ]
 build-backend = "hatchling.build"

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: 'ubuntu-20.04'
+  os: "ubuntu-22.04"
   tools:
-    python: 'mambaforge-4.10'
+    python: "mambaforge-4.10"
 
 conda:
   environment: docs/environment.yml

--- a/share/jupyter/voila/templates/reveal/index.html.j2
+++ b/share/jupyter/voila/templates/reveal/index.html.j2
@@ -5,7 +5,6 @@
 
 {%- block html_head_js -%}
   {%- block html_head_js_requirejs -%}
-  {{ resources.include_js("static/require.min.js") }}
   {%- endblock html_head_js_requirejs -%}
   {%- block html_head_js_logs -%}
     {{ log.js() }}
@@ -122,5 +121,12 @@
 
 {% block footer_js %}
   {{ voila_setup(resources.base_url, resources.labextensions) }}
-  {{ super() }}
+  <script type="text/javascript">
+    window.reveal_transition = "{{reveal_transition}}";
+    window.reveal_number = "{{reveal_number}}";
+    window.reveal_width = {{reveal_width}};
+    window.reveal_height = {{reveal_height}};
+    window.reveal_scroll = {{reveal_scroll}};
+  </script>
+  <script src="{{ page_config['fullStaticUrl'] | e }}/reveal.js"></script>
 {% endblock footer_js %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -15092,10 +15092,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"reveal.js@npm:^6.0.1":
+"reveal.js@npm:6.0.1":
   version: 6.0.1
   resolution: "reveal.js@npm:6.0.1"
   checksum: b8fa860fc1a492fc2bbffe5e6da839ef6c7f9b49c673df1f594a2c412933a3156ab848c1a444d067be47145b1d0dec8b93d3f58b182215c69d2aa1d2ea79e7cc
+  languageName: node
+  linkType: hard
+
+"reveal.js@patch:reveal.js@npm%3A6.0.1#./.yarn/patches/reveal.js-npm-6.0.1-1c7308d1ac.patch::locator=%40voila-dashboards%2Fvoila-root%40workspace%3A.":
+  version: 6.0.1
+  resolution: "reveal.js@patch:reveal.js@npm%3A6.0.1#./.yarn/patches/reveal.js-npm-6.0.1-1c7308d1ac.patch::version=6.0.1&hash=f63989&locator=%40voila-dashboards%2Fvoila-root%40workspace%3A."
+  checksum: 422d60e5c5fc85bc61a1584a350165ba9472434e6940ad7b23fb8f48c7de03ae2bd4a1c04f7168662cb4f924e2637b21414ebf9e70e51072f174b8d12bfc4944
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4960,6 +4960,7 @@ __metadata:
     p-limit: ^2.2.2
     react: ^18.2.0
     react-dom: ^18.2.0
+    reveal.js: ^6.0.1
     rimraf: ^3.0.2
     style-loader: ~3.3.1
     style-mod: ^4.0.3
@@ -15088,6 +15089,13 @@ __metadata:
   version: 1.0.4
   resolution: "reusify@npm:1.0.4"
   checksum: c3076ebcc22a6bc252cb0b9c77561795256c22b757f40c0d8110b1300723f15ec0fc8685e8d4ea6d7666f36c79ccc793b1939c748bf36f18f542744a4e379fcc
+  languageName: node
+  linkType: hard
+
+"reveal.js@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "reveal.js@npm:6.0.1"
+  checksum: b8fa860fc1a492fc2bbffe5e6da839ef6c7f9b49c673df1f594a2c412933a3156ab848c1a444d067be47145b1d0dec8b93d3f58b182215c69d2aa1d2ea79e7cc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## References

The newly built ipywidgets 8.1.9 was made using the new jupyter-builder package which uses rspack instead of webpack. This does not play well with the combination of:
- requirejs put in the page by the reveal.js template
- backbone detecting require.js and this condition is true https://github.com/jashkenas/backbone/blob/master/backbone.js#L16 then backbone hides itself from rspack (`backbone__rspack_import_0` is undefined) resulting in ipywidgets failing to import backbone.

This PR works around this by removing requirejs from the page, and processing reveal with webpack instead of having it raw in the template.